### PR TITLE
CI using GitHub Actions

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,6 +1,6 @@
 name: Dart CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,22 @@
+name: Dart CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    container:
+      image:  google/dart:latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install ObjectBox C-API
+      run: ./install.sh
+    - name: Install dependencies
+      run: pub get
+    - name: Generate ObjectBox models
+      run: pub run build_runner build
+    - name: Run tests
+      run: pub run test

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eu
+
+cLibVersion=0.7
+os=$(uname)
+
+# if there's no tty this is probably part of a docker build - therefore we install the c-api explicitly
+cLibArgs=
+if [[ "$os" != MINGW* ]] && [[ "$os" != CYGWIN* ]]; then
+  tty -s || cLibArgs="${cLibArgs} --install"
+fi
+
+bash <(curl -s https://raw.githubusercontent.com/objectbox/objectbox-c/master/download.sh) ${cLibArgs} ${cLibVersion}


### PR DESCRIPTION
GitHub Actions should become generally available on Nov 13th and is free for public repositories.

https://github.com/features/actions

This PR does a simple build & test as described by README.md

In action: https://github.com/vaind/objectbox-dart/actions