### PR TITLE
Export observable.dart

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,6 @@ Streams can be created from queries.
 Note: Dart Streams can be extended with [rxdart](https://github.com/ReactiveX/rxdart).
 
 ```dart
-    import "package:objectbox/src/observable.dart";
-
     // final store = ...
     final query = box.query(condition).build();
     final queryStream = query.stream;

--- a/example/flutter/objectbox_demo/lib/main.dart
+++ b/example/flutter/objectbox_demo/lib/main.dart
@@ -3,7 +3,6 @@ import 'package:objectbox/objectbox.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'objectbox.g.dart';
-import 'package:objectbox/src/observable.dart';
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/objectbox.dart
+++ b/lib/objectbox.dart
@@ -10,5 +10,6 @@ export 'src/box.dart';
 export 'src/common.dart';
 export 'src/model.dart';
 export 'src/modelinfo/index.dart';
+export 'src/observable.dart';
 export 'src/query/query.dart';
 export 'src/store.dart';


### PR DESCRIPTION
Please ignore if it's intentional to optionally import `observable.dart` due to the use of extensions / support for earlier dart SDKs -- the reason for PR was to satisfy analyzer linter rule for `implementation_imports` (Don't import implementation files from another package.)