### PR TITLE
Async callbacks & multi-isolate store access

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -26,10 +26,8 @@ jobs:
           - macos-10.15
           - ubuntu-20.04
         dart:
-          - 2.10.5
-          # - 2.9.3 - generator stuck. I remember there was an issue in some dependency but don't remember which one.
-          - 2.8.4
-          - 2.7.2
+          - latest
+          - 2.10.0 # currently the lowest fully supported version (i.e. generator + lib)
     runs-on: ${{ matrix.os }}
     steps:
       # Note: dart-sdk from flutter doesn't work on linux, see https://github.com/flutter/flutter/issues/74599

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -2,7 +2,7 @@ name: objectbox_benchmark
 description: Simple ObjectBox-Dart performance benchmark
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
   objectbox: any

--- a/flutter_libs/android/build.gradle
+++ b/flutter_libs/android/build.gradle
@@ -12,5 +12,5 @@ android {
 
 dependencies {
     // https://bintray.com/objectbox/objectbox/io.objectbox%3Aobjectbox-android
-    implementation "io.objectbox:objectbox-android:2.8.0"
+    implementation "io.objectbox:objectbox-android:2.9.0"
 }

--- a/flutter_libs/ios/download-framework.sh
+++ b/flutter_libs/ios/download-framework.sh
@@ -4,19 +4,21 @@ set -euo pipefail
 # NOTE: run this script before publishing
 
 # https://github.com/objectbox/objectbox-swift/releases/
-obxSwiftVersion="1.4.1"
+obxSwiftVersion="1.5.0-beta1"
 
 dir=$(dirname "$0")
 
-url="https://github.com/objectbox/objectbox-swift/releases/download/v${obxSwiftVersion}/ObjectBox-framework-${obxSwiftVersion}.zip"
+url="https://github.com/objectbox/objectbox-swift-spec-staging/releases/download/v1.x/ObjectBox-xcframework-${obxSwiftVersion}.zip"
 zip="${dir}/fw.zip"
 
 curl --location --fail --output "${zip}" "${url}"
 
+frameworkPath=Carthage/Build/ObjectBox.xcframework/ios-arm64/ObjectBox.framework
+
 rm -rf "${dir}/Carthage"
 unzip "${zip}" -d "${dir}" \
-  "Carthage/Build/iOS/ObjectBox.framework/Headers/*" \
-  "Carthage/Build/iOS/ObjectBox.framework/ObjectBox" \
-  "Carthage/Build/iOS/ObjectBox.framework/Info.plist"
+  "${frameworkPath}/Headers/*" \
+  "${frameworkPath}/ObjectBox" \
+  "${frameworkPath}/Info.plist"
 
 rm "${zip}"

--- a/flutter_libs/pubspec.yaml
+++ b/flutter_libs/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://objectbox.io
 description: ObjectBox is a super-fast NoSQL ACID compliant object database. This package contains flutter runtime libraries for ObjectBox.
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
-  flutter: ">=1.12.0 <2.0.0"
+  sdk: ">=2.9.0 <3.0.0"
+  flutter: ">=1.20.0 <2.0.0"
 
 dependencies:
   # This is here just to ensure compatibility between objectbox-dart code and the libraries used

--- a/generator/integration-tests/shared-pubspec.yaml
+++ b/generator/integration-tests/shared-pubspec.yaml
@@ -1,7 +1,7 @@
 name: objectbox_generator_test
 
 environment:
-  sdk: ">=2.5.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
   objectbox: any

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -5,7 +5,8 @@ homepage: https://objectbox.io
 description: ObjectBox binding code generator - finds annotated entities and adds them to the ObjectBox DB model.
 
 environment:
-  sdk: ">=2.5.0 <3.0.0"
+  # min SDK v2.10.0 (or Flutter v1.22) - there were breaking changes in the analyzer/resolver
+  sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
   objectbox: 0.11.0

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ set -eu
 #   * update lib/src/bindings/objectbox.h
 #   * execute pub run ffigen
 #   * have a look at the changed files to see if some call sites need to be updated
-cLibVersion=0.11.0
+cLibVersion=0.12.0
 os=$(uname)
 
 # if there's no tty this is probably part of a docker build - therefore we install the c-api explicitly

--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -1,3 +1,9 @@
+## latest
+
+* Update to objectbox-c v0.12.0
+* Update to objectbox-android v2.9.0
+* Update to objectbox-swift v1.5.0
+
 ## 0.11.0 (2021-02-01)
 
 * Add `ToOne<>` class to wrap related entities. See examples for details.

--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Update to objectbox-c v0.12.0
 * Update to objectbox-android v2.9.0
 * Update to objectbox-swift v1.5.0
+* Increase minimum SDK versions: Flutter v1.20 & Dart v2.9. Code generator already required Flutter v1.22 & Dart v2.10. 
 
 ## 0.11.0 (2021-02-01)
 

--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## latest
 
+* Add `Store.reference` getter and `Store.fromReference()` factory - enabling access to store from multiple isolates.
+* Add `Store.subscribe<EntityType>()` and `Store.subscribe<EntityType>()` data change event streams.
+* Add multiple `SyncClient` event streams.
 * Update to objectbox-c v0.12.0
 * Update to objectbox-android v2.9.0
 * Update to objectbox-swift v1.5.0

--- a/objectbox/Makefile
+++ b/objectbox/Makefile
@@ -20,7 +20,7 @@ test: 			## Test all targets
 
 valgrind-test: 		## Test all targets with valgrind
 	pub run build_runner build
-	../tool/valgrind.sh
+	tool/valgrind.sh
 
 integration-test:	## Execute integration tests
 	cd example/flutter/objectbox_demo/						; \

--- a/objectbox/example/README.md
+++ b/objectbox/example/README.md
@@ -96,7 +96,7 @@ omits the argument to `Store(directory: )`, thus using the default - 'objectbox'
 import 'objectbox.g.dart'; // created by `dart pub run build_runner build`
 
 void main() {
-  var store = Store(getObjectBoxModel()); // Note: getObjectBoxModel() is generated for you in objectbox.g.dart
+  final store = Store(getObjectBoxModel()); // Note: getObjectBoxModel() is generated for you in objectbox.g.dart
 
   // your app code ...
 

--- a/objectbox/example/flutter/objectbox_demo/pubspec.yaml
+++ b/objectbox/example/flutter/objectbox_demo/pubspec.yaml
@@ -3,7 +3,8 @@ description: An example project for the objectbox-dart binding.
 version: 0.3.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
+  flutter: ">=1.22.0 <2.0.0"
 
 dependencies:
   flutter:

--- a/objectbox/example/flutter/objectbox_demo_sync/lib/objectbox-model.json
+++ b/objectbox/example/flutter/objectbox_demo_sync/lib/objectbox-model.json
@@ -30,7 +30,8 @@
           "name": "date",
           "type": 6
         }
-      ]
+      ],
+      "relations": []
     }
   ],
   "lastEntityId": "1:2802681814019499133",

--- a/objectbox/example/flutter/objectbox_demo_sync/pubspec.yaml
+++ b/objectbox/example/flutter/objectbox_demo_sync/pubspec.yaml
@@ -3,7 +3,8 @@ description: An example project for the objectbox-dart binding.
 version: 0.3.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
+  flutter: ">=1.22.0 <2.0.0"
 
 dependencies:
   flutter:

--- a/objectbox/lib/objectbox.dart
+++ b/objectbox/lib/objectbox.dart
@@ -23,5 +23,13 @@ export 'src/relations/to_many.dart' show ToMany;
 export 'src/relations/to_one.dart' show ToOne;
 export 'src/store.dart' show Store;
 export 'src/sync.dart'
-    show Sync, SyncClient, SyncCredentials, SyncRequestUpdatesMode, SyncState;
+    show
+        Sync,
+        SyncChange,
+        SyncClient,
+        SyncConnectionEvent,
+        SyncCredentials,
+        SyncRequestUpdatesMode,
+        SyncState,
+        SyncLoginEvent;
 export 'src/transaction.dart' show TxMode;

--- a/objectbox/lib/src/bindings/bindings.dart
+++ b/objectbox/lib/src/bindings/bindings.dart
@@ -46,3 +46,15 @@ ObjectBoxC loadObjectBoxLib() {
 ObjectBoxC /*?*/ _cachedBindings;
 
 ObjectBoxC get C => _cachedBindings ??= loadObjectBoxLib();
+
+/// Init DartAPI in C for async callbacks - only needs to be called once.
+/// See the following issue:
+/// https://github.com/objectbox/objectbox-dart/issues/143
+void initializeDartAPI() {
+  if (!_dartAPIinitialized) {
+    _dartAPIinitialized = true;
+    C.dart_init_api(NativeApi.initializeApiDLData);
+  }
+}
+
+bool _dartAPIinitialized = false;

--- a/objectbox/lib/src/bindings/bindings.dart
+++ b/objectbox/lib/src/bindings/bindings.dart
@@ -56,7 +56,7 @@ ObjectBoxC get C => _cachedBindings ??= loadObjectBoxLib();
 /// See https://github.com/objectbox/objectbox-dart/issues/143
 void initializeDartAPI() {
   if (_dartAPIinitialized == null) {
-    final errCode = C.dart_init_api(NativeApi.initializeApiDLData);
+    final errCode = C.dartc_init_api(NativeApi.initializeApiDLData);
     _dartAPIinitialized = (OBX_SUCCESS == errCode);
     if (!_dartAPIinitialized) {
       _dartAPIinitException = latestNativeError(codeIfMissing: errCode);

--- a/objectbox/lib/src/bindings/bindings.dart
+++ b/objectbox/lib/src/bindings/bindings.dart
@@ -59,7 +59,13 @@ void initializeDartAPI() {
     final errCode = C.dartc_init_api(NativeApi.initializeApiDLData);
     _dartAPIinitialized = (OBX_SUCCESS == errCode);
     if (!_dartAPIinitialized) {
-      _dartAPIinitException = latestNativeError(codeIfMissing: errCode);
+      _dartAPIinitException = latestNativeError(
+          codeIfMissing: errCode,
+          dartMsg: "Dart/Flutter SDK you're using is not compatible with "
+              'ObjectBox observers, query streams and Sync event streams. '
+              'Please consider using Flutter v1.20.x or v1.22.x (or Dart v2.10.x). '
+              'See https://github.com/objectbox/objectbox-dart/issues/197 for more details. '
+              'Native exception');
     }
   }
 

--- a/objectbox/lib/src/bindings/objectbox-c.dart
+++ b/objectbox/lib/src/bindings/objectbox-c.dart
@@ -49,7 +49,8 @@ class ObjectBoxC {
   _dart_version_is_at_least _version_is_at_least;
 
   /// /// Return the version of the library to be printed.
-  /// /// The format may change; to query for version use the int based methods instead.
+  /// /// The format may change in any future release; only use for information purposes.
+  /// /// @see obx_version() and obx_version_is_at_least()
   ffi.Pointer<ffi.Int8> version_string() {
     _version_string ??=
         _dylib.lookupFunction<_c_version_string, _dart_version_string>(
@@ -60,7 +61,8 @@ class ObjectBoxC {
   _dart_version_string _version_string;
 
   /// /// Return the version of the ObjectBox core to be printed.
-  /// /// The format may change, do not rely on its current form.
+  /// /// The format may change in any future release; only use for information purposes.
+  /// /// @see obx_version() and obx_version_is_at_least()
   ffi.Pointer<ffi.Int8> version_core_string() {
     _version_core_string ??= _dylib.lookupFunction<_c_version_core_string,
         _dart_version_core_string>('obx_version_core_string');
@@ -68,6 +70,40 @@ class ObjectBoxC {
   }
 
   _dart_version_core_string _version_core_string;
+
+  /// /// Checks whether the given feature is available in the currently loaded library.
+  bool has_feature(
+    int feature,
+  ) {
+    _has_feature ??= _dylib
+        .lookupFunction<_c_has_feature, _dart_has_feature>('obx_has_feature');
+    return _has_feature(
+          feature,
+        ) !=
+        0;
+  }
+
+  _dart_has_feature _has_feature;
+
+  /// /// Check whether functions returning OBX_bytes_array are fully supported (depends on build, invariant during runtime)
+  /// /// @deprecated use obx_has_feature(OBXFeature_BytesArray) instead
+  bool supports_bytes_array() {
+    _supports_bytes_array ??= _dylib.lookupFunction<_c_supports_bytes_array,
+        _dart_supports_bytes_array>('obx_supports_bytes_array');
+    return _supports_bytes_array() != 0;
+  }
+
+  _dart_supports_bytes_array _supports_bytes_array;
+
+  /// /// Check whether time series functions are available in the version of this library
+  /// /// @deprecated use obx_has_feature(OBXFeature_TimeSeries) instead
+  bool supports_time_series() {
+    _supports_time_series ??= _dylib.lookupFunction<_c_supports_time_series,
+        _dart_supports_time_series>('obx_supports_time_series');
+    return _supports_time_series() != 0;
+  }
+
+  _dart_supports_time_series _supports_time_series;
 
   /// /// Delete the store files from the given directory
   int remove_db_files(
@@ -82,24 +118,6 @@ class ObjectBoxC {
   }
 
   _dart_remove_db_files _remove_db_files;
-
-  /// /// Check whether functions returning OBX_bytes_array are fully supported (depends on build, invariant during runtime)
-  bool supports_bytes_array() {
-    _supports_bytes_array ??= _dylib.lookupFunction<_c_supports_bytes_array,
-        _dart_supports_bytes_array>('obx_supports_bytes_array');
-    return _supports_bytes_array() != 0;
-  }
-
-  _dart_supports_bytes_array _supports_bytes_array;
-
-  /// /// Check whether time series functions are available in the version of this library
-  bool supports_time_series() {
-    _supports_time_series ??= _dylib.lookupFunction<_c_supports_time_series,
-        _dart_supports_time_series>('obx_supports_time_series');
-    return _supports_time_series() != 0;
-  }
-
-  _dart_supports_time_series _supports_time_series;
 
   /// /// Return the error status on the current thread and clear the error state.
   /// /// The buffer returned in out_message is valid only until the next call into ObjectBox.
@@ -4737,6 +4755,7 @@ class ObjectBoxC {
   /// /// Before calling any of the other sync APIs, ensure that those are actually available.
   /// /// If the application is linked a non-sync ObjectBox library, this allows you to fail gracefully.
   /// /// @return true if this library comes with the sync API
+  /// /// @deprecated use obx_has_feature(OBXFeature_Sync)
   bool sync_available() {
     _sync_available ??=
         _dylib.lookupFunction<_c_sync_available, _dart_sync_available>(
@@ -4780,7 +4799,7 @@ class ObjectBoxC {
   /// /// Sets credentials to authenticate the client with the server.
   /// /// See OBXSyncCredentialsType for available options.
   /// /// The accepted OBXSyncCredentials type depends on your sync-server configuration.
-  /// /// @param data may be NULL, i.e. in combination with OBXSyncCredentialsType_UNCHECKED
+  /// /// @param data may be NULL, i.e. in combination with OBXSyncCredentialsType_NONE
   int sync_credentials(
     ffi.Pointer<OBX_sync> sync_1,
     int type,
@@ -5095,6 +5114,186 @@ class ObjectBoxC {
   }
 
   _dart_sync_listener_change _sync_listener_change;
+
+  /// /// Initializes Dart API - call before any other obx_dart_* functions.
+  int dartc_init_api(
+    ffi.Pointer<ffi.Void> data,
+  ) {
+    _dartc_init_api ??=
+        _dylib.lookupFunction<_c_dartc_init_api, _dart_dartc_init_api>(
+            'obx_dart_init_api');
+    return _dartc_init_api(
+      data,
+    );
+  }
+
+  _dart_dartc_init_api _dartc_init_api;
+
+  /// /// @see obx_observe()
+  /// /// Note: use obx_observer_close() to free unassign the observer and free resources after you're done with it
+  ffi.Pointer<OBX_observer> dartc_observe(
+    ffi.Pointer<OBX_store> store,
+    int native_port,
+  ) {
+    _dartc_observe ??=
+        _dylib.lookupFunction<_c_dartc_observe, _dart_dartc_observe>(
+            'obx_dart_observe');
+    return _dartc_observe(
+      store,
+      native_port,
+    );
+  }
+
+  _dart_dartc_observe _dartc_observe;
+
+  ffi.Pointer<OBX_observer> dartc_observe_single_type(
+    ffi.Pointer<OBX_store> store,
+    int type_id,
+    int native_port,
+  ) {
+    _dartc_observe_single_type ??= _dylib.lookupFunction<
+        _c_dartc_observe_single_type,
+        _dart_dartc_observe_single_type>('obx_dart_observe_single_type');
+    return _dartc_observe_single_type(
+      store,
+      type_id,
+      native_port,
+    );
+  }
+
+  _dart_dartc_observe_single_type _dartc_observe_single_type;
+
+  /// /// @param listener may be NULL
+  int dartc_sync_listener_close(
+    ffi.Pointer<OBX_dart_sync_listener> listener,
+  ) {
+    _dartc_sync_listener_close ??= _dylib.lookupFunction<
+        _c_dartc_sync_listener_close,
+        _dart_dartc_sync_listener_close>('obx_dart_sync_listener_close');
+    return _dartc_sync_listener_close(
+      listener,
+    );
+  }
+
+  _dart_dartc_sync_listener_close _dartc_sync_listener_close;
+
+  ffi.Pointer<OBX_dart_sync_listener> dartc_sync_listener_connect(
+    ffi.Pointer<OBX_sync> sync_1,
+    int native_port,
+  ) {
+    _dartc_sync_listener_connect ??= _dylib.lookupFunction<
+        _c_dartc_sync_listener_connect,
+        _dart_dartc_sync_listener_connect>('obx_dart_sync_listener_connect');
+    return _dartc_sync_listener_connect(
+      sync_1,
+      native_port,
+    );
+  }
+
+  _dart_dartc_sync_listener_connect _dartc_sync_listener_connect;
+
+  /// /// @see obx_sync_listener_disconnect()
+  ffi.Pointer<OBX_dart_sync_listener> dartc_sync_listener_disconnect(
+    ffi.Pointer<OBX_sync> sync_1,
+    int native_port,
+  ) {
+    _dartc_sync_listener_disconnect ??= _dylib.lookupFunction<
+            _c_dartc_sync_listener_disconnect,
+            _dart_dartc_sync_listener_disconnect>(
+        'obx_dart_sync_listener_disconnect');
+    return _dartc_sync_listener_disconnect(
+      sync_1,
+      native_port,
+    );
+  }
+
+  _dart_dartc_sync_listener_disconnect _dartc_sync_listener_disconnect;
+
+  /// /// @see obx_sync_listener_login()
+  ffi.Pointer<OBX_dart_sync_listener> dartc_sync_listener_login(
+    ffi.Pointer<OBX_sync> sync_1,
+    int native_port,
+  ) {
+    _dartc_sync_listener_login ??= _dylib.lookupFunction<
+        _c_dartc_sync_listener_login,
+        _dart_dartc_sync_listener_login>('obx_dart_sync_listener_login');
+    return _dartc_sync_listener_login(
+      sync_1,
+      native_port,
+    );
+  }
+
+  _dart_dartc_sync_listener_login _dartc_sync_listener_login;
+
+  /// /// @see obx_sync_listener_login_failure()
+  ffi.Pointer<OBX_dart_sync_listener> dartc_sync_listener_login_failure(
+    ffi.Pointer<OBX_sync> sync_1,
+    int native_port,
+  ) {
+    _dartc_sync_listener_login_failure ??= _dylib.lookupFunction<
+            _c_dartc_sync_listener_login_failure,
+            _dart_dartc_sync_listener_login_failure>(
+        'obx_dart_sync_listener_login_failure');
+    return _dartc_sync_listener_login_failure(
+      sync_1,
+      native_port,
+    );
+  }
+
+  _dart_dartc_sync_listener_login_failure _dartc_sync_listener_login_failure;
+
+  /// /// @see obx_sync_listener_complete()
+  ffi.Pointer<OBX_dart_sync_listener> dartc_sync_listener_complete(
+    ffi.Pointer<OBX_sync> sync_1,
+    int native_port,
+  ) {
+    _dartc_sync_listener_complete ??= _dylib.lookupFunction<
+        _c_dartc_sync_listener_complete,
+        _dart_dartc_sync_listener_complete>('obx_dart_sync_listener_complete');
+    return _dartc_sync_listener_complete(
+      sync_1,
+      native_port,
+    );
+  }
+
+  _dart_dartc_sync_listener_complete _dartc_sync_listener_complete;
+
+  /// /// @see obx_sync_listener_change()
+  ffi.Pointer<OBX_dart_sync_listener> dartc_sync_listener_change(
+    ffi.Pointer<OBX_sync> sync_1,
+    int native_port,
+  ) {
+    _dartc_sync_listener_change ??= _dylib.lookupFunction<
+        _c_dartc_sync_listener_change,
+        _dart_dartc_sync_listener_change>('obx_dart_sync_listener_change');
+    return _dartc_sync_listener_change(
+      sync_1,
+      native_port,
+    );
+  }
+
+  _dart_dartc_sync_listener_change _dartc_sync_listener_change;
+}
+
+abstract class OBXFeature {
+  /// /// Functions that are returning multiple results (e.g. multiple objects) can be only used if this is available.
+  /// /// This is only available for 64-bit OSes and is the opposite of "chunked mode", which forces to consume results
+  /// /// in chunks (e.g. one by one).
+  /// /// Since chunked mode consumes a bit less RAM, ResultArray style functions are typically only preferable if
+  /// /// there's an additional overhead per call, e.g. caused by a higher level language abstraction like CGo.
+  static const int ResultArray = 1;
+
+  /// /// TimeSeries support (date/date-nano companion ID and other time-series functionality).
+  static const int TimeSeries = 2;
+
+  /// /// Sync client availability. Visit https://objectbox.io/sync for more details.
+  static const int Sync = 3;
+
+  /// /// Check whether debug log can be enabled during runtime.
+  static const int DebugLog = 4;
+
+  /// /// HTTP server with a database browser.
+  static const int ObjectBrowser = 5;
 }
 
 abstract class OBXPropertyType {
@@ -5139,6 +5338,15 @@ abstract class OBXEntityFlags {
   /// /// Enable "data synchronization" for this entity type: objects will be synced with other stores over the network.
   /// /// It's possible to have local-only (non-synced) types and synced types in the same store (schema/data model).
   static const int SYNC_ENABLED = 2;
+
+  /// /// Makes object IDs for a synced types (SYNC_ENABLED is set) global.
+  /// /// By default (not using this flag), the 64 bit object IDs have a local scope and are not unique globally.
+  /// /// This flag tells ObjectBox to treat object IDs globally and thus no ID mapping (local <-> global) is performed.
+  /// /// Often this is used with assignable IDs (ID_SELF_ASSIGNABLE property flag is set) and some special ID scheme.
+  /// /// Note: typically you won't do this with automatically assigned IDs, set by the local ObjectBox store.
+  /// ///       Two devices would likely overwrite each other's object during sync as object IDs are prone to collide.
+  /// ///       It might be OK if you can somehow ensure that only a single device will create new IDs.
+  static const int SHARED_GLOBAL_IDS = 4;
 }
 
 /// /// Bit-flags defining the behavior of properties.
@@ -5453,6 +5661,8 @@ class OBX_sync_change_array extends ffi.Struct {
   int count;
 }
 
+class OBX_dart_sync_listener extends ffi.Struct {}
+
 const int OBX_VERSION_MAJOR = 0;
 
 const int OBX_VERSION_MINOR = 11;
@@ -5527,6 +5737,10 @@ const int OBX_ERROR_FILE_PAGES_CORRUPT = 10503;
 
 const int OBX_ERROR_SCHEMA_OBJECT_NOT_FOUND = 10504;
 
+const int OBX_ERROR_TIME_SERIES_NOT_AVAILABLE = 10601;
+
+const int OBX_ERROR_SYNC_NOT_AVAILABLE = 10602;
+
 typedef _c_version = ffi.Void Function(
   ffi.Pointer<ffi.Int32> major,
   ffi.Pointer<ffi.Int32> minor,
@@ -5559,12 +5773,12 @@ typedef _c_version_core_string = ffi.Pointer<ffi.Int8> Function();
 
 typedef _dart_version_core_string = ffi.Pointer<ffi.Int8> Function();
 
-typedef _c_remove_db_files = ffi.Int32 Function(
-  ffi.Pointer<ffi.Int8> directory,
+typedef _c_has_feature = ffi.Uint8 Function(
+  ffi.Int32 feature,
 );
 
-typedef _dart_remove_db_files = int Function(
-  ffi.Pointer<ffi.Int8> directory,
+typedef _dart_has_feature = int Function(
+  int feature,
 );
 
 typedef _c_supports_bytes_array = ffi.Uint8 Function();
@@ -5574,6 +5788,14 @@ typedef _dart_supports_bytes_array = int Function();
 typedef _c_supports_time_series = ffi.Uint8 Function();
 
 typedef _dart_supports_time_series = int Function();
+
+typedef _c_remove_db_files = ffi.Int32 Function(
+  ffi.Pointer<ffi.Int8> directory,
+);
+
+typedef _dart_remove_db_files = int Function(
+  ffi.Pointer<ffi.Int8> directory,
+);
 
 typedef _c_last_error_pop = ffi.Uint8 Function(
   ffi.Pointer<ffi.Int32> out_error,
@@ -8695,4 +8917,114 @@ typedef _dart_sync_listener_change = void Function(
   ffi.Pointer<OBX_sync> sync_1,
   ffi.Pointer<ffi.NativeFunction<OBX_sync_listener_change>> listener,
   ffi.Pointer<ffi.Void> listener_arg,
+);
+
+typedef _c_dartc_init_api = ffi.Int32 Function(
+  ffi.Pointer<ffi.Void> data,
+);
+
+typedef _dart_dartc_init_api = int Function(
+  ffi.Pointer<ffi.Void> data,
+);
+
+typedef _c_dartc_observe = ffi.Pointer<OBX_observer> Function(
+  ffi.Pointer<OBX_store> store,
+  ffi.Int64 native_port,
+);
+
+typedef _dart_dartc_observe = ffi.Pointer<OBX_observer> Function(
+  ffi.Pointer<OBX_store> store,
+  int native_port,
+);
+
+typedef _c_dartc_observe_single_type = ffi.Pointer<OBX_observer> Function(
+  ffi.Pointer<OBX_store> store,
+  ffi.Uint32 type_id,
+  ffi.Int64 native_port,
+);
+
+typedef _dart_dartc_observe_single_type = ffi.Pointer<OBX_observer> Function(
+  ffi.Pointer<OBX_store> store,
+  int type_id,
+  int native_port,
+);
+
+typedef _c_dartc_sync_listener_close = ffi.Int32 Function(
+  ffi.Pointer<OBX_dart_sync_listener> listener,
+);
+
+typedef _dart_dartc_sync_listener_close = int Function(
+  ffi.Pointer<OBX_dart_sync_listener> listener,
+);
+
+typedef _c_dartc_sync_listener_connect = ffi.Pointer<OBX_dart_sync_listener>
+    Function(
+  ffi.Pointer<OBX_sync> sync_1,
+  ffi.Int64 native_port,
+);
+
+typedef _dart_dartc_sync_listener_connect = ffi.Pointer<OBX_dart_sync_listener>
+    Function(
+  ffi.Pointer<OBX_sync> sync_1,
+  int native_port,
+);
+
+typedef _c_dartc_sync_listener_disconnect = ffi.Pointer<OBX_dart_sync_listener>
+    Function(
+  ffi.Pointer<OBX_sync> sync_1,
+  ffi.Int64 native_port,
+);
+
+typedef _dart_dartc_sync_listener_disconnect
+    = ffi.Pointer<OBX_dart_sync_listener> Function(
+  ffi.Pointer<OBX_sync> sync_1,
+  int native_port,
+);
+
+typedef _c_dartc_sync_listener_login = ffi.Pointer<OBX_dart_sync_listener>
+    Function(
+  ffi.Pointer<OBX_sync> sync_1,
+  ffi.Int64 native_port,
+);
+
+typedef _dart_dartc_sync_listener_login = ffi.Pointer<OBX_dart_sync_listener>
+    Function(
+  ffi.Pointer<OBX_sync> sync_1,
+  int native_port,
+);
+
+typedef _c_dartc_sync_listener_login_failure
+    = ffi.Pointer<OBX_dart_sync_listener> Function(
+  ffi.Pointer<OBX_sync> sync_1,
+  ffi.Int64 native_port,
+);
+
+typedef _dart_dartc_sync_listener_login_failure
+    = ffi.Pointer<OBX_dart_sync_listener> Function(
+  ffi.Pointer<OBX_sync> sync_1,
+  int native_port,
+);
+
+typedef _c_dartc_sync_listener_complete = ffi.Pointer<OBX_dart_sync_listener>
+    Function(
+  ffi.Pointer<OBX_sync> sync_1,
+  ffi.Int64 native_port,
+);
+
+typedef _dart_dartc_sync_listener_complete = ffi.Pointer<OBX_dart_sync_listener>
+    Function(
+  ffi.Pointer<OBX_sync> sync_1,
+  int native_port,
+);
+
+typedef _c_dartc_sync_listener_change = ffi.Pointer<OBX_dart_sync_listener>
+    Function(
+  ffi.Pointer<OBX_sync> sync_1,
+  ffi.Int64 native_port,
+);
+
+typedef _dart_dartc_sync_listener_change = ffi.Pointer<OBX_dart_sync_listener>
+    Function(
+  ffi.Pointer<OBX_sync> sync_1,
+  int native_port,
 );

--- a/objectbox/lib/src/bindings/objectbox-dart.h
+++ b/objectbox/lib/src/bindings/objectbox-dart.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 ObjectBox Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBJECTBOX_DART_H
+#define OBJECTBOX_DART_H
+
+#include <stdint.h>
+
+#include "objectbox.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//----------------------------------------------
+// Dart-specific binding
+//
+// Following section provides [Dart](https://dart.dev) specific async callbacks integration.
+// These functions are only used internally by [objectbox-dart](https://github.com/objectbox/objectbox-dart) binding.
+// In short - instead of issuing callbacks from background threads, their messages are sent to Dart over NativePorts.
+//----------------------------------------------
+
+/// Initializes Dart API - call before any other obx_dart_* functions.
+obx_err obx_dart_init_api(void* data);
+
+/// @see obx_observe()
+/// Note: use obx_observer_close() to free unassign the observer and free resources after you're done with it
+OBX_observer* obx_dart_observe(OBX_store* store, int64_t native_port);
+
+// @see obx_observe_single_type()
+OBX_observer* obx_dart_observe_single_type(OBX_store* store, obx_schema_id type_id, int64_t native_port);
+
+// Note: use OBX_dart_sync_listener_close() to unassign the listener and free native resources
+struct OBX_dart_sync_listener;
+typedef struct OBX_dart_sync_listener OBX_dart_sync_listener;
+
+/// @param listener may be NULL
+obx_err obx_dart_sync_listener_close(OBX_dart_sync_listener* listener);
+
+// @see obx_sync_listener_connect()
+OBX_dart_sync_listener* obx_dart_sync_listener_connect(OBX_sync* sync, int64_t native_port);
+
+/// @see obx_sync_listener_disconnect()
+OBX_dart_sync_listener* obx_dart_sync_listener_disconnect(OBX_sync* sync, int64_t native_port);
+
+/// @see obx_sync_listener_login()
+OBX_dart_sync_listener* obx_dart_sync_listener_login(OBX_sync* sync, int64_t native_port);
+
+/// @see obx_sync_listener_login_failure()
+OBX_dart_sync_listener* obx_dart_sync_listener_login_failure(OBX_sync* sync, int64_t native_port);
+
+/// @see obx_sync_listener_complete()
+OBX_dart_sync_listener* obx_dart_sync_listener_complete(OBX_sync* sync, int64_t native_port);
+
+/// @see obx_sync_listener_change()
+OBX_dart_sync_listener* obx_dart_sync_listener_change(OBX_sync* sync, int64_t native_port);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OBJECTBOX_DART_H

--- a/objectbox/lib/src/bindings/objectbox.h
+++ b/objectbox/lib/src/bindings/objectbox.h
@@ -266,6 +266,15 @@ typedef enum {
     /// Enable "data synchronization" for this entity type: objects will be synced with other stores over the network.
     /// It's possible to have local-only (non-synced) types and synced types in the same store (schema/data model).
     OBXEntityFlags_SYNC_ENABLED = 2,
+
+    /// Makes object IDs for a synced types (SYNC_ENABLED is set) global.
+    /// By default (not using this flag), the 64 bit object IDs have a local scope and are not unique globally.
+    /// This flag tells ObjectBox to treat object IDs globally and thus no ID mapping (local <-> global) is performed.
+    /// Often this is used with assignable IDs (ID_SELF_ASSIGNABLE property flag is set) and some special ID scheme.
+    /// Note: typically you won't do this with automatically assigned IDs, set by the local ObjectBox store.
+    ///       Two devices would likely overwrite each other's object during sync as object IDs are prone to collide.
+    ///       It might be OK if you can somehow ensure that only a single device will create new IDs.
+    OBXEntityFlags_SHARED_GLOBAL_IDS = 4,
 } OBXEntityFlags;
 
 /// Bit-flags defining the behavior of properties.
@@ -1869,49 +1878,6 @@ void obx_sync_listener_complete(OBX_sync* sync, OBX_sync_listener_complete* list
 /// @param listener set NULL to reset
 /// @param listener_arg is a pass-through argument passed to the listener
 void obx_sync_listener_change(OBX_sync* sync, OBX_sync_listener_change* listener, void* listener_arg);
-
-//----------------------------------------------
-// Dart-specific binding
-//
-// Following section provides [Dart](https://dart.dev) specific async callbacks integration.
-// These functions are only used internally by [objectbox-dart](https://github.com/objectbox/objectbox-dart) binding.
-// In short - instead of issuing callbacks from background threads, their messages are sent to Dart over NativePorts.
-//----------------------------------------------
-
-/// Initializes Dart API - call before any other obx_dart_* functions.
-obx_err obx_dart_init_api(void* data);
-
-/// @see obx_observe()
-/// Note: use obx_observer_close() to free unassign the observer and free resources after you're done with it
-OBX_observer* obx_dart_observe(OBX_store* store, int64_t native_port);
-
-// @see obx_observe_single_type()
-OBX_observer* obx_dart_observe_single_type(OBX_store* store, obx_schema_id type_id, int64_t native_port);
-
-// Note: use OBX_dart_sync_listener_close() to unassign the listener and free native resources
-struct OBX_dart_sync_listener;
-typedef struct OBX_dart_sync_listener OBX_dart_sync_listener;
-
-/// @param listener may be NULL
-obx_err OBX_dart_sync_listener_close(OBX_dart_sync_listener* listener);
-
-// @see obx_sync_listener_connect()
-OBX_dart_sync_listener* obx_dart_sync_listener_connect(OBX_sync* sync, int64_t native_port);
-
-/// @see obx_sync_listener_disconnect()
-OBX_dart_sync_listener* obx_dart_sync_listener_disconnect(OBX_sync* sync, int64_t native_port);
-
-/// @see obx_sync_listener_login()
-OBX_dart_sync_listener* obx_dart_sync_listener_login(OBX_sync* sync, int64_t native_port);
-
-/// @see obx_sync_listener_login_failure()
-OBX_dart_sync_listener* obx_dart_sync_listener_login_failure(OBX_sync* sync, int64_t native_port);
-
-/// @see obx_sync_listener_complete()
-OBX_dart_sync_listener* obx_dart_sync_listener_complete(OBX_sync* sync, int64_t native_port);
-
-/// @see obx_sync_listener_change()
-OBX_dart_sync_listener* obx_dart_sync_listener_change(OBX_sync* sync, int64_t native_port);
 
 #ifdef __cplusplus
 }

--- a/objectbox/lib/src/bindings/objectbox.h
+++ b/objectbox/lib/src/bindings/objectbox.h
@@ -165,6 +165,10 @@ bool obx_supports_time_series(void);
 /// A requested schema object (e.g., an entity or a property) was not found in the schema
 #define OBX_ERROR_SCHEMA_OBJECT_NOT_FOUND 10504
 
+/// Feature specific errors
+#define OBX_ERROR_TIME_SERIES_NOT_AVAILABLE 10601
+#define OBX_ERROR_SYNC_NOT_AVAILABLE 10602
+
 //----------------------------------------------
 // Error info; obx_last_error_*
 //----------------------------------------------
@@ -1734,7 +1738,7 @@ obx_err obx_sync_close(OBX_sync* sync);
 /// Sets credentials to authenticate the client with the server.
 /// See OBXSyncCredentialsType for available options.
 /// The accepted OBXSyncCredentials type depends on your sync-server configuration.
-/// @param data may be NULL, i.e. in combination with OBXSyncCredentialsType_UNCHECKED
+/// @param data may be NULL, i.e. in combination with OBXSyncCredentialsType_NONE
 obx_err obx_sync_credentials(OBX_sync* sync, OBXSyncCredentialsType type, const void* data, size_t size);
 
 /// Configures the maximum number of outgoing TX messages that can be sent without an ACK from the server.
@@ -1829,6 +1833,14 @@ void obx_sync_listener_complete(OBX_sync* sync, OBX_sync_listener_complete* list
 /// @param listener set NULL to reset
 /// @param listener_arg is a pass-through argument passed to the listener
 void obx_sync_listener_change(OBX_sync* sync, OBX_sync_listener_change* listener, void* listener_arg);
+
+obx_err obx_dart_init_api(void* data);
+
+/// @see obx_observe()
+/// Note: use obx_observer_close() to free unassign the observer and free resources after you're done with it
+OBX_observer* obx_dart_observe(OBX_store* store, int64_t dart_native_port);
+
+OBX_observer* obx_dart_observe_single_type(OBX_store* store, obx_schema_id type_id, int64_t dart_native_port);
 
 #ifdef __cplusplus
 }

--- a/objectbox/lib/src/box.dart
+++ b/objectbox/lib/src/box.dart
@@ -51,7 +51,7 @@ class Box<T> {
             .any((ModelProperty prop) => prop.isRelation),
         _hasToManyRelations = _entity.model.relations.isNotEmpty ||
             _entity.model.backlinks.isNotEmpty,
-        _cBox = C.box(_store.ptr, _entity.model.id.id) {
+        _cBox = C.box(InternalStoreAccess.ptr(_store), _entity.model.id.id) {
     checkObxPtr(_cBox, 'failed to create box');
   }
 

--- a/objectbox/lib/src/observable.dart
+++ b/objectbox/lib/src/observable.dart
@@ -65,7 +65,7 @@ extension ObservableStore on Store {
   /// done with it to avoid hanging change listeners.
   Stream<void> subscribe<EntityT>() {
     final observer = _Observer<void>();
-    final entityId = entityDef<EntityT>().model.id.id;
+    final entityId = InternalStoreAccess.entityDef<EntityT>(this).model.id.id;
 
     observer.init(() {
       // We're listening to events on single entity so there's no argument.
@@ -74,7 +74,7 @@ extension ObservableStore on Store {
       observer.receivePort = ReceivePort()
         ..listen((_) => observer.controller.add(null));
       observer.cObserver =
-          C.dart_observe_single_type(ptr, entityId, observer.nativePort);
+          C.dartc_observe_single_type(ptr, entityId, observer.nativePort);
     });
 
     return observer.stream;
@@ -91,8 +91,9 @@ extension ObservableStore on Store {
 
     // create a map from Entity ID to Entity type (dart class)
     final entityTypesById = <int, Type>{};
-    defs.bindings.forEach((Type entity, EntityDefinition entityDef) =>
-        entityTypesById[entityDef.model.id.id] = entity);
+    InternalStoreAccess.defs(this).bindings.forEach(
+        (Type entity, EntityDefinition entityDef) =>
+            entityTypesById[entityDef.model.id.id] = entity);
 
     observer.init(() {
       // We're listening to a events for all entity types. C-API sends entity ID
@@ -121,7 +122,7 @@ extension ObservableStore on Store {
             }
           });
         });
-      observer.cObserver = C.dart_observe(ptr, observer.nativePort);
+      observer.cObserver = C.dartc_observe(ptr, observer.nativePort);
     });
 
     return observer.stream;

--- a/objectbox/lib/src/observable.dart
+++ b/objectbox/lib/src/observable.dart
@@ -1,91 +1,132 @@
 import 'dart:async';
 import 'dart:ffi';
+import 'dart:isolate';
 
 import 'bindings/bindings.dart';
+import 'bindings/helpers.dart';
+import 'modelinfo/entity_definition.dart';
 import 'query/query.dart';
 import 'store.dart';
-import 'util.dart';
 
-// ignore_for_file: non_constant_identifier_names
+/// Simple wrapper used below in ObservableStore to reduce code duplication.
+/// Contains shared code for single-entity observer and the generic/global one.
+class _Observer<StreamValueType> {
+  StreamController<StreamValueType> /*?*/ controller;
+  Pointer<OBX_observer> /*?*/ _cObserver;
+  ReceivePort /*?*/ receivePort;
 
-// dart callback signature
-typedef _Any = void Function(Pointer<Void>, Pointer<Uint32>, int);
+  int get nativePort => receivePort /*!*/ .sendPort.nativePort;
 
-class _Observable {
-  static final _anyObserver = <int, Pointer<OBX_observer>>{};
-  static final _any = <int, Map<int, _Any>>{};
-
-  // sync:true -> ObjectBoxException: 10001 TX is not active anymore: #101
-  static final controller = StreamController<int>.broadcast();
-
-  // The user_data is used to pass the store ptr address
-  // in case there is no consensus on the entity id between stores
-  static void _anyCallback(
-      Pointer<Void> user_data, Pointer<Uint32> mutated_ids, int mutated_count) {
-    final storeAddress = user_data.address;
-    // call schema's callback
-    final storeCallbacks = _any[storeAddress];
-    if (storeCallbacks != null) {
-      for (var i = 0; i < mutated_count; i++) {
-        storeCallbacks[mutated_ids[i]]
-            ?.call(user_data, mutated_ids, mutated_count);
-      }
-    }
+  set cObserver(Pointer<OBX_observer> value) {
+    _cObserver = checkObxPtr(value, 'observer initialization failed');
+    _debugLog('started');
   }
 
-  static void subscribe(Store store) {
-    syncOrObserversExclusive.mark(store);
+  Stream<StreamValueType> get stream => controller /*!*/ .stream;
 
-    final callback = Pointer.fromFunction<obx_observer>(_anyCallback);
-    final storePtr = store.ptr;
-    _anyObserver[storePtr.address] =
-        C.observe(storePtr, callback, storePtr.cast<Void>());
-    InternalStoreAccess.addCloseListener(store, _anyObserver[storePtr.address],
-        () {
-      unsubscribe(store);
+  _Observer() {
+    initializeDartAPI();
+  }
+
+  // start() is called whenever user starts listen()-ing to the stream
+  void init(void Function() start) {
+    controller = StreamController<StreamValueType>(
+        onListen: start, onPause: stop, onResume: start, onCancel: stop);
+  }
+
+  // stop() is called when the stream subscription is paused or canceled
+  void stop() {
+    _debugLog('stopped');
+    if (_cObserver != null) checkObx(C.observer_close(_cObserver));
+  }
+
+  void _debugLog(String message) {
+    // print('Observer=${_cObserver?.address} ' + message);
+  }
+}
+
+/// StreamController implementation inspired by the sample controller sample at:
+/// https://dart.dev/articles/libraries/creating-streams#honoring-the-pause-state
+/// https://dart.dev/articles/libraries/code/stream_controller.dart
+extension ObservableStore on Store {
+  /// Create a stream to data changes on EntityT (stored Entity class).
+  ///
+  /// The stream receives an event whenever an object of EntityT is created or
+  /// changed or deleted. Make sure to close() the subscription after you're
+  /// done with it to avoid hanging change listeners.
+  Stream<void> subscribe<EntityT>() {
+    final observer = _Observer<void>();
+    final entityId = entityDef<EntityT>().model.id.id;
+
+    observer.init(() {
+      // We're listening to events on single entity so there's no argument.
+      // Ideally, controller.add() would work but it doesn't, even though we're
+      // using StreamController<Void> so the argument type is `void`.
+      observer.receivePort = ReceivePort()
+        ..listen((_) => observer.controller.add(null));
+      observer.cObserver =
+          C.dart_observe_single_type(ptr, entityId, observer.nativePort);
     });
+
+    return observer.stream;
   }
 
-  // #53 ffi:Pointer finalizer
-  static void unsubscribe(Store store) {
-    final storeAddress = store.ptr.address;
-    if (!_anyObserver.containsKey(storeAddress)) {
-      return;
-    }
-    InternalStoreAccess.removeCloseListener(store, _anyObserver[storeAddress]);
-    C.observer_close(_anyObserver[storeAddress]);
-    _anyObserver.remove(storeAddress);
-    syncOrObserversExclusive.unmark(store);
-  }
+  /// Create a stream to data changes on all Entity types.
+  ///
+  /// The stream receives an even whenever any data changes in the database.
+  /// Make sure to close() the subscription after you're done with it to avoid
+  /// hanging change listeners.
+  Stream<Type> subscribeAll() {
+    initializeDartAPI();
+    final observer = _Observer<Type>();
 
-  static bool isSubscribed(Store store) =>
-      _Observable._anyObserver.containsKey(store.ptr.address);
+    // create a map from Entity ID to Entity type (dart class)
+    final entityTypesById = <int, Type>{};
+    defs.bindings.forEach((Type entity, EntityDefinition entityDef) =>
+        entityTypesById[entityDef.model.id.id] = entity);
+
+    observer.init(() {
+      // We're listening to a events for all entity types. C-API sends entity ID
+      // and we must map it to a dart type (class) corresponding to that entity.
+      observer.receivePort = ReceivePort()
+        ..listen((entityIds) {
+          if (entityIds is! List) {
+            observer.controller.addError(Exception(
+                'Received invalid data format from the core notification: (${entityIds.runtimeType}) $entityIds'));
+            return;
+          }
+
+          entityIds.forEach((entityId) {
+            if (entityId is! int) {
+              observer.controller.addError(Exception(
+                  'Received invalid item data format from the core notification: (${entityId.runtimeType}) $entityId'));
+              return;
+            }
+
+            final entityType = entityTypesById[entityId];
+            if (entityType == null) {
+              observer.controller.addError(Exception(
+                  'Received data change notification for an unknown entity ID $entityId'));
+            } else {
+              observer.controller.add(entityType);
+            }
+          });
+        });
+      observer.cObserver = C.dart_observe(ptr, observer.nativePort);
+    });
+
+    return observer.stream;
+  }
 }
 
 /// Streamable adds stream support to queries. The stream reruns the query
 /// whenever there's a change in any of the objects in the queried Box
 /// (regardless of the filter conditions).
 extension Streamable<T> on Query<T> {
-  void _setup() {
-    if (!_Observable.isSubscribed(store)) {
-      _Observable.subscribe(store);
-    }
-    final storeAddress = store.ptr.address;
-
-    _Observable._any[storeAddress] ??= <int, _Any>{};
-    _Observable._any[storeAddress] /*!*/ [entityId] ??= (u, _, __) {
-      // dummy value to trigger an event
-      _Observable.controller.add(entityId);
-    };
-  }
-
-  /// Create a stream, executing [Query.find()] whenever there's a change to any
-  /// of the objects in the queried Box.
   Stream<List<T>> findStream(
       {@Deprecated('Use offset() instead') int offset = 0,
       @Deprecated('Use limit() instead') int limit = 0}) {
-    _setup();
-    return _Observable.controller.stream.where((e) => e == entityId).map((_) {
+    return store.subscribe<T>().map((_) {
       if (offset != 0) this.offset(offset);
       if (limit != 0) this.limit(limit);
       return find();
@@ -94,9 +135,6 @@ extension Streamable<T> on Query<T> {
 
   /// Use this for Query Property
   Stream<Query<T>> get stream {
-    _setup();
-    return _Observable.controller.stream
-        .where((e) => e == entityId)
-        .map((_) => this);
+    return store.subscribe<T>().map((_) => this);
   }
 }

--- a/objectbox/lib/src/observable.dart
+++ b/objectbox/lib/src/observable.dart
@@ -72,7 +72,7 @@ extension ObservableStore on Store {
       // Ideally, controller.add() would work but it doesn't, even though we're
       // using StreamController<Void> so the argument type is `void`.
       observer.receivePort = ReceivePort()
-        ..listen((_) => observer.controller.add(null));
+        ..listen((dynamic _) => observer.controller.add(null));
       observer.cObserver =
           C.dartc_observe_single_type(ptr, entityId, observer.nativePort);
     });
@@ -99,14 +99,14 @@ extension ObservableStore on Store {
       // We're listening to a events for all entity types. C-API sends entity ID
       // and we must map it to a dart type (class) corresponding to that entity.
       observer.receivePort = ReceivePort()
-        ..listen((entityIds) {
+        ..listen((dynamic entityIds) {
           if (entityIds is! Uint32List) {
             observer.controller.addError(Exception(
                 'Received invalid data format from the core notification: (${entityIds.runtimeType}) $entityIds'));
             return;
           }
 
-          entityIds.forEach((entityId) {
+          (entityIds as Uint32List).forEach((int entityId) {
             if (entityId is! int) {
               observer.controller.addError(Exception(
                   'Received invalid item data format from the core notification: (${entityId.runtimeType}) $entityId'));
@@ -133,18 +133,17 @@ extension ObservableStore on Store {
 /// whenever there's a change in any of the objects in the queried Box
 /// (regardless of the filter conditions).
 extension Streamable<T> on Query<T> {
+  /// Create a stream, executing [Query.find()] whenever there's a change to any
+  /// of the objects in the queried Box.
   Stream<List<T>> findStream(
-      {@Deprecated('Use offset() instead') int offset = 0,
-      @Deprecated('Use limit() instead') int limit = 0}) {
-    return store.subscribe<T>().map((_) {
-      if (offset != 0) this.offset(offset);
-      if (limit != 0) this.limit(limit);
-      return find();
-    });
-  }
+          {@Deprecated('Use offset() instead') int offset = 0,
+          @Deprecated('Use limit() instead') int limit = 0}) =>
+      store.subscribe<T>().map((_) {
+        if (offset != 0) this.offset(offset);
+        if (limit != 0) this.limit(limit);
+        return find();
+      });
 
   /// Use this for Query Property
-  Stream<Query<T>> get stream {
-    return store.subscribe<T>().map((_) => this);
-  }
+  Stream<Query<T>> get stream => store.subscribe<T>().map((_) => this);
 }

--- a/objectbox/lib/src/observable.dart
+++ b/objectbox/lib/src/observable.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ffi';
 import 'dart:isolate';
+import 'dart:typed_data';
 
 import 'bindings/bindings.dart';
 import 'bindings/helpers.dart';
@@ -98,7 +99,7 @@ extension ObservableStore on Store {
       // and we must map it to a dart type (class) corresponding to that entity.
       observer.receivePort = ReceivePort()
         ..listen((entityIds) {
-          if (entityIds is! List) {
+          if (entityIds is! Uint32List) {
             observer.controller.addError(Exception(
                 'Received invalid data format from the core notification: (${entityIds.runtimeType}) $entityIds'));
             return;

--- a/objectbox/lib/src/observable.dart
+++ b/objectbox/lib/src/observable.dart
@@ -37,11 +37,19 @@ class _Observer<StreamValueType> {
   // stop() is called when the stream subscription is paused or canceled
   void stop() {
     _debugLog('stopped');
-    if (_cObserver != null) checkObx(C.observer_close(_cObserver));
+    if (_cObserver != null) {
+      checkObx(C.observer_close(_cObserver));
+      _cObserver = null;
+    }
+
+    if (receivePort != null) {
+      receivePort.close();
+      receivePort = null;
+    }
   }
 
   void _debugLog(String message) {
-    // print('Observer=${_cObserver?.address} ' + message);
+    // print('Observer=${_cObserver?.address} $message');
   }
 }
 
@@ -52,7 +60,7 @@ extension ObservableStore on Store {
   /// Create a stream to data changes on EntityT (stored Entity class).
   ///
   /// The stream receives an event whenever an object of EntityT is created or
-  /// changed or deleted. Make sure to close() the subscription after you're
+  /// changed or deleted. Make sure to cancel() the subscription after you're
   /// done with it to avoid hanging change listeners.
   Stream<void> subscribe<EntityT>() {
     final observer = _Observer<void>();
@@ -74,7 +82,7 @@ extension ObservableStore on Store {
   /// Create a stream to data changes on all Entity types.
   ///
   /// The stream receives an even whenever any data changes in the database.
-  /// Make sure to close() the subscription after you're done with it to avoid
+  /// Make sure to cancel() the subscription after you're done with it to avoid
   /// hanging change listeners.
   Stream<Type> subscribeAll() {
     initializeDartAPI();

--- a/objectbox/lib/src/query/builder.dart
+++ b/objectbox/lib/src/query/builder.dart
@@ -5,7 +5,11 @@ class QueryBuilder<T> extends _QueryBuilder<T> {
   /// Start creating a query.
   QueryBuilder(Store store, EntityDefinition<T> entity, Condition /*?*/ qc)
       : super(
-            store, entity, qc, C.query_builder(store.ptr, entity.model.id.id));
+            store,
+            entity,
+            qc,
+            C.query_builder(
+                InternalStoreAccess.ptr(store), entity.model.id.id));
 
   /// Finish building a [Query]. Call [Query.close()] after you're done with it
   /// to free resources.

--- a/objectbox/lib/src/store.dart
+++ b/objectbox/lib/src/store.dart
@@ -102,6 +102,9 @@ class Store {
     }
   }
 
+  /// Create a Dart store instance from an already opened native store pointer.
+  /// Used for example to create use the same store from multiple isolates, with
+  /// the pointer passed over a stream.
   Store.fromPtr(this._defs, this._cStore)
       : _weak = true; // must not close the same native store twice
 
@@ -165,6 +168,9 @@ class Store {
 class InternalStoreAccess {
   /// Access entity model for the given class (Dart Type).
   static EntityDefinition<T> entityDef<T>(Store store) => store._entityDef();
+
+  /// Access model definitions
+  static ModelDefinition defs(Store store) => store._defs;
 
   /// Adds a listener to the [store.close()] event.
   static void addCloseListener(

--- a/objectbox/lib/src/store.dart
+++ b/objectbox/lib/src/store.dart
@@ -24,6 +24,10 @@ class Store {
   final _onClose = <dynamic, void Function()>{};
 
   /// Creates a BoxStore using the model definition from the generated
+  /// whether this store was created from a pointer (won't close in that case)
+  bool _weak = false;
+
+  /// Creates a BoxStore using the model definition from your
   /// `objectbox.g.dart` file.
   ///
   /// For example in a Flutter app:
@@ -98,7 +102,8 @@ class Store {
     }
   }
 
-  Store.fromPtr(this.defs, this._cStore);
+  Store.fromPtr(this._defs, this._cStore)
+      : _weak = true; // must not close the same native store twice
 
   /// Closes this store.
   ///
@@ -115,7 +120,7 @@ class Store {
     _onClose.values.toList(growable: false).forEach((listener) => listener());
     _onClose.clear();
 
-    checkObx(C.store_close(_cStore));
+    if (!_weak) checkObx(C.store_close(_cStore));
   }
 
   /// Returns a cached Box instance.

--- a/objectbox/lib/src/store.dart
+++ b/objectbox/lib/src/store.dart
@@ -18,6 +18,7 @@ class Store {
   /*late final*/ Pointer<OBX_store> _cStore;
   final _boxes = <Type, Box>{};
   final ModelDefinition _defs;
+  bool _closed = false;
 
   /// A list of observers of the Store.close() event.
   final _onClose = <dynamic, void Function()>{};
@@ -103,6 +104,9 @@ class Store {
   ///
   /// Don't try to call any other ObjectBox methods after the store is closed.
   void close() {
+    if (_closed) return;
+    _closed = true;
+
     _boxes.values.forEach(InternalBoxAccess.close);
     _boxes.clear();
 

--- a/objectbox/lib/src/store.dart
+++ b/objectbox/lib/src/store.dart
@@ -97,6 +97,8 @@ class Store {
     }
   }
 
+  Store.fromPtr(this.defs, this._cStore);
+
   /// Closes this store.
   ///
   /// Don't try to call any other ObjectBox methods after the store is closed.

--- a/objectbox/lib/src/sync.dart
+++ b/objectbox/lib/src/sync.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:convert' show utf8;
 import 'dart:ffi';
+import 'dart:isolate';
 import 'dart:typed_data' show Uint8List;
 
 import 'package:ffi/ffi.dart';
@@ -83,6 +85,9 @@ enum SyncRequestUpdatesMode {
   /// server. Similar to calling [SyncClient.requestUpdates(false)].
   autoNoPushes
 }
+
+/// Connection state change event
+enum SyncConnectionStateChange { connected, disconnected }
 
 /// Sync client is used to connect to an ObjectBox sync server.
 class SyncClient {
@@ -233,6 +238,128 @@ class SyncClient {
     } finally {
       free(count);
     }
+  }
+
+  Stream<SyncConnectionStateChange> connectionStateChanges() {
+    // This stream combines events from two C listeners: connect & disconnect.
+    final group = _SyncListenerGroup('sync-connection');
+
+    group.add(_SyncListenerConfig(
+        (int nativePort) =>
+            bindings.obx_dart_sync_listener_connect(ptr, nativePort),
+        (_, controller) =>
+            controller.add(SyncConnectionStateChange.connected)));
+
+    group.add(_SyncListenerConfig(
+        (int nativePort) =>
+            bindings.obx_dart_sync_listener_disconnect(ptr, nativePort),
+        (_, controller) =>
+            controller.add(SyncConnectionStateChange.disconnected)));
+
+    return group.finish();
+  }
+}
+
+/// Configuration for _SyncListenerGroup, setting up a single native listener.
+class _SyncListenerConfig {
+  /// Function to create a new native listener.
+  final Pointer<OBX_dart_sync_listener> Function(int nativePort) cListenerInit;
+
+  /// Called on message from a native listener.
+  final void Function(dynamic msg, StreamController controller) dartListener;
+
+  _SyncListenerConfig(this.cListenerInit, this.dartListener);
+}
+
+/// Wrapper used in SyncClient for event listeners forwarding.
+/// Supports merging events from multiple native listeners to a single stream.
+class _SyncListenerGroup<StreamValueType> {
+  final String name;
+  bool finished = false;
+
+  /*late final*/
+  StreamController<StreamValueType> controller;
+  final _configs = <_SyncListenerConfig>[];
+
+  // currently active native listeners and ports attached to them
+  final _cListeners = <Pointer<OBX_dart_sync_listener>>[];
+  final _receivePorts = <ReceivePort>[];
+
+  /// start() is called whenever user starts listen()-ing to the stream
+  _SyncListenerGroup(this.name) {
+    initializeDartAPI();
+  }
+
+  /// Add a native->dart forwarder config to the group.
+  void add(_SyncListenerConfig config) {
+    assert(!finished, "Can't add more listners after calling finish().");
+    _configs.add(config);
+  }
+
+  /// Finish the group, creating a listener.
+  Stream<StreamValueType> finish() {
+    assert(!finished, 'finish() may only be called once.');
+    controller = StreamController<StreamValueType>(
+        onListen: _start, onPause: _stop, onResume: _start, onCancel: _stop);
+    return controller.stream;
+  }
+
+  // stop() is called when the stream subscription is started or resumed
+  void _start() {
+    _debugLog('starting');
+    assert(finished, 'Starting an unfinished group?!');
+
+    var hasError = false;
+    _configs.forEach((_SyncListenerConfig config) {
+      if (hasError) return;
+
+      // Initialize a receive port where the native listener will post messages.
+      final receivePort = ReceivePort()
+        ..listen((msg) => config.dartListener(msg, controller));
+
+      // Store the ReceivePort to be able to close it in _stop().
+      _receivePorts.add(receivePort);
+
+      // Start the native listener.
+      final cListener = config.cListenerInit(receivePort.sendPort.nativePort);
+      if (cListener == null) {
+        hasError = true;
+      } else {
+        _cListeners.add(cListener);
+      }
+    });
+
+    if (hasError) {
+      try {
+        throw latestNativeError(
+            dartMsg: 'Failed to initialize a sync native listener');
+      } finally {
+        _stop();
+      }
+    }
+
+    _debugLog('started');
+  }
+
+  // stop() is called when the stream subscription is paused or canceled
+  void _stop() {
+    _debugLog('stopping');
+    assert(finished, 'Starting an unfinished group?!');
+
+    final cErrorCodes = _cListeners.map(bindings.OBX_dart_sync_listener_close);
+    _cListeners.clear();
+
+    _receivePorts.forEach((rp) => rp.close());
+    _receivePorts.clear();
+
+    // throw on native, if any
+    cErrorCodes.map(checkObx);
+
+    _debugLog('stopped');
+  }
+
+  void _debugLog(String message) {
+    print('Listener ${name}: $message');
   }
 }
 

--- a/objectbox/lib/src/sync.dart
+++ b/objectbox/lib/src/sync.dart
@@ -275,6 +275,47 @@ class Sync {
   }
 }
 
+/* BACKUP: Sync change listener async callback message handling
+  ReceivePort()..listen((syncChanges) {
+          if (syncChanges is! List) {
+            observer.controller.addError(Exception(
+                'Received invalid data type from the core notification: (${syncChanges.runtimeType}) $syncChanges'));
+            return;
+          }
+
+          // List<SyncChange> is flattened to List<dynamic>, with SyncChange object
+          // properties always coming in groups of three (entityId, puts, removals)
+          const numProperties = 3;
+          if (syncChanges.length % numProperties != 0) {
+            observer.controller.addError(Exception(
+                'Received invalid list length from the core notification: (${syncChanges.runtimeType}) $syncChanges'));
+            return;
+          }
+
+          for (var i = 0; i < syncChanges.length / numProperties; i++) {
+            final entityId = syncChanges[i * numProperties + 0];
+            final putsBytes = syncChanges[i * numProperties + 1];
+            final removalsBytes = syncChanges[i * numProperties + 2];
+
+            if (entityId is! int ||
+                putsBytes is! Uint8List ||
+                removalsBytes is! Uint8List) {
+              observer.controller.addError(Exception(
+                  'Received invalid list items format from the core notification at i=${i}: '
+                  'entityId = (${entityId.runtimeType}) $entityId; '
+                  'putsBytes = (${putsBytes.runtimeType}) $putsBytes; '
+                  'removalsBytes = (${removalsBytes.runtimeType}) $removalsBytes'));
+              return;
+            }
+
+            final puts = Uint64List.view(putsBytes.buffer).toList();
+            final removals = Uint64List.view(removalsBytes.buffer).toList();
+
+            // forward the event with entityId, puts & removals
+          }
+      });
+*/
+
 /// Tests only.
 // TODO enable annotation once meta:1.3.0 is out
 // @internal

--- a/objectbox/lib/src/sync.dart
+++ b/objectbox/lib/src/sync.dart
@@ -514,7 +514,7 @@ class _SyncListenerGroup<StreamValueType> {
   }
 
   void _debugLog(String message) {
-    print('Listener ${name}: $message');
+    // print('Listener ${name}: $message');
   }
 }
 

--- a/objectbox/lib/src/sync.dart
+++ b/objectbox/lib/src/sync.dart
@@ -269,11 +269,11 @@ class SyncClient {
           _SyncListenerGroup<SyncConnectionEvent>('sync-connection');
 
       _connectionEvents.add(_SyncListenerConfig(
-          (int nativePort) => C.dart_sync_listener_connect(ptr, nativePort),
+          (int nativePort) => C.dartc_sync_listener_connect(ptr, nativePort),
           (_, controller) => controller.add(SyncConnectionEvent.connected)));
 
       _connectionEvents.add(_SyncListenerConfig(
-          (int nativePort) => C.dart_sync_listener_disconnect(ptr, nativePort),
+          (int nativePort) => C.dartc_sync_listener_disconnect(ptr, nativePort),
           (_, controller) => controller.add(SyncConnectionEvent.disconnected)));
 
       _connectionEvents.finish();
@@ -292,12 +292,12 @@ class SyncClient {
       _loginEvents = _SyncListenerGroup<SyncLoginEvent>('sync-login');
 
       _loginEvents.add(_SyncListenerConfig(
-          (int nativePort) => C.dart_sync_listener_login(ptr, nativePort),
+          (int nativePort) => C.dartc_sync_listener_login(ptr, nativePort),
           (_, controller) => controller.add(SyncLoginEvent.loggedIn)));
 
       _loginEvents.add(_SyncListenerConfig(
           (int nativePort) =>
-              C.dart_sync_listener_login_failure(ptr, nativePort),
+              C.dartc_sync_listener_login_failure(ptr, nativePort),
           (code, controller) {
         // see OBXSyncCode - TODO should we match any other codes?
         switch (code) {
@@ -324,7 +324,7 @@ class SyncClient {
       _completionEvents = _SyncListenerGroup<void>('sync-completion');
 
       _completionEvents.add(_SyncListenerConfig(
-          (int nativePort) => C.dart_sync_listener_complete(ptr, nativePort),
+          (int nativePort) => C.dartc_sync_listener_complete(ptr, nativePort),
           (_, controller) => controller.add(null)));
 
       _completionEvents.finish();
@@ -344,11 +344,12 @@ class SyncClient {
 
       // create a map from Entity ID to Entity type (dart class)
       final entityTypesById = <int, Type>{};
-      _store.defs.bindings.forEach((Type entity, EntityDefinition entityDef) =>
-          entityTypesById[entityDef.model.id.id] = entity);
+      InternalStoreAccess.defs(_store).bindings.forEach(
+          (Type entity, EntityDefinition entityDef) =>
+              entityTypesById[entityDef.model.id.id] = entity);
 
       _changeEvents.add(_SyncListenerConfig(
-          (int nativePort) => C.dart_sync_listener_change(ptr, nativePort),
+          (int nativePort) => C.dartc_sync_listener_change(ptr, nativePort),
           (syncChanges, controller) {
         if (syncChanges is! List) {
           controller.addError(Exception(
@@ -500,7 +501,7 @@ class _SyncListenerGroup<StreamValueType> {
     assert(finished, 'Stopping an unfinished group?!');
 
     final cErrorCodes = _cListeners
-        .map(C.dart_sync_listener_close) // map() is lazy
+        .map(C.dartc_sync_listener_close) // map() is lazy
         .toList(growable: false); // call toList() to execute immediately
     _cListeners.clear();
 

--- a/objectbox/lib/src/sync.dart
+++ b/objectbox/lib/src/sync.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert' show utf8;
 import 'dart:ffi';
 import 'dart:isolate';
-import 'dart:typed_data' show Uint8List;
+import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
@@ -92,6 +92,16 @@ enum SyncConnectionEvent { connected, disconnected }
 /// Login state change event.
 enum SyncLoginEvent { loggedIn, credentialsRejected, unknownError }
 
+/// Sync incoming data event.
+class SyncChange {
+  final int entityId;
+  final Type entity;
+  final List<int> puts;
+  final List<int> removals;
+
+  SyncChange(this.entityId, this.entity, this.puts, this.removals);
+}
+
 /// Sync client is used to connect to an ObjectBox sync server.
 class SyncClient {
   final Store _store;
@@ -131,6 +141,7 @@ class SyncClient {
     _connectionEvents?._stop();
     _loginEvents?._stop();
     _completionEvents?._stop();
+    _changeEvents?._stop();
     final err = C.sync_close(_cSync);
     _cSync = nullptr;
     syncClientsStorage.remove(_store);
@@ -253,7 +264,7 @@ class SyncClient {
   /// Subscribe (listen) to the stream to actually start listening to events.
   Stream<SyncConnectionEvent> get connectionEvents {
     if (_connectionEvents == null) {
-      // This stream combines events from two C listeners: connect & disconnect.
+      // Combine events from two C listeners: connect & disconnect.
       _connectionEvents =
           _SyncListenerGroup<SyncConnectionEvent>('sync-connection');
 
@@ -277,7 +288,7 @@ class SyncClient {
   /// Subscribe (listen) to the stream to actually start listening to events.
   Stream<SyncLoginEvent> get loginEvents {
     if (_loginEvents == null) {
-      // This stream combines events from two C listeners: connect & disconnect.
+      // Combine events from two C listeners: login & login-failure.
       _loginEvents = _SyncListenerGroup<SyncLoginEvent>('sync-login');
 
       _loginEvents.add(_SyncListenerConfig(
@@ -319,6 +330,78 @@ class SyncClient {
       _completionEvents.finish();
     }
     return _completionEvents.stream;
+  }
+
+  _SyncListenerGroup<List<SyncChange>> /*?*/ _changeEvents;
+
+  /// Get a broadcast stream of incoming synced data changes.
+  ///
+  /// Subscribe (listen) to the stream to actually start listening to events.
+  Stream<List<SyncChange>> get changeEvents {
+    if (_changeEvents == null) {
+      // This stream combines events from two C listeners: connect & disconnect.
+      _changeEvents = _SyncListenerGroup<List<SyncChange>>('sync-change');
+
+      // create a map from Entity ID to Entity type (dart class)
+      final entityTypesById = <int, Type>{};
+      _store.defs.bindings.forEach((Type entity, EntityDefinition entityDef) =>
+          entityTypesById[entityDef.model.id.id] = entity);
+
+      _changeEvents.add(_SyncListenerConfig(
+          (int nativePort) => C.dart_sync_listener_change(ptr, nativePort),
+          (syncChanges, controller) {
+        if (syncChanges is! List) {
+          controller.addError(Exception(
+              'Received invalid data type from the core notification: (${syncChanges.runtimeType}) $syncChanges'));
+          return;
+        }
+
+        // List<SyncChange> is flattened to List<dynamic>, with SyncChange object
+        // properties always coming in groups of three (entityId, puts, removals)
+        const numProperties = 3;
+        if (syncChanges.length % numProperties != 0) {
+          controller.addError(Exception(
+              'Received invalid list length from the core notification: (${syncChanges.runtimeType}) $syncChanges'));
+          return;
+        }
+
+        final changes = <SyncChange>[];
+        for (var i = 0; i < syncChanges.length / numProperties; i++) {
+          final entityId = syncChanges[i * numProperties + 0];
+          final putsBytes = syncChanges[i * numProperties + 1];
+          final removalsBytes = syncChanges[i * numProperties + 2];
+
+          final entityType = entityTypesById[entityId];
+          if (entityType == null) {
+            controller.addError(Exception(
+                'Received sync change notification for an unknown entity ID $entityId'));
+            return;
+          }
+
+          if (entityId is! int ||
+              putsBytes is! Uint8List ||
+              removalsBytes is! Uint8List) {
+            controller.addError(Exception(
+                'Received invalid list items format from the core notification at i=${i}: '
+                'entityId = (${entityId.runtimeType}) $entityId; '
+                'putsBytes = (${putsBytes.runtimeType}) $putsBytes; '
+                'removalsBytes = (${removalsBytes.runtimeType}) $removalsBytes'));
+            return;
+          }
+
+          changes.add(SyncChange(
+              entityId,
+              entityType,
+              Uint64List.view(putsBytes.buffer).toList(),
+              Uint64List.view(removalsBytes.buffer).toList()));
+        }
+
+        controller.add(changes);
+      }));
+
+      _changeEvents.finish();
+    }
+    return _changeEvents.stream;
   }
 }
 
@@ -392,7 +475,7 @@ class _SyncListenerGroup<StreamValueType> {
 
       // Start the native listener.
       final cListener = config.cListenerInit(receivePort.sendPort.nativePort);
-      if (cListener == null) {
+      if (cListener == null || cListener == nullptr) {
         hasError = true;
       } else {
         _cListeners.add(cListener);
@@ -473,47 +556,6 @@ class Sync {
     return client;
   }
 }
-
-/* BACKUP: Sync change listener async callback message handling
-  ReceivePort()..listen((syncChanges) {
-          if (syncChanges is! List) {
-            observer.controller.addError(Exception(
-                'Received invalid data type from the core notification: (${syncChanges.runtimeType}) $syncChanges'));
-            return;
-          }
-
-          // List<SyncChange> is flattened to List<dynamic>, with SyncChange object
-          // properties always coming in groups of three (entityId, puts, removals)
-          const numProperties = 3;
-          if (syncChanges.length % numProperties != 0) {
-            observer.controller.addError(Exception(
-                'Received invalid list length from the core notification: (${syncChanges.runtimeType}) $syncChanges'));
-            return;
-          }
-
-          for (var i = 0; i < syncChanges.length / numProperties; i++) {
-            final entityId = syncChanges[i * numProperties + 0];
-            final putsBytes = syncChanges[i * numProperties + 1];
-            final removalsBytes = syncChanges[i * numProperties + 2];
-
-            if (entityId is! int ||
-                putsBytes is! Uint8List ||
-                removalsBytes is! Uint8List) {
-              observer.controller.addError(Exception(
-                  'Received invalid list items format from the core notification at i=${i}: '
-                  'entityId = (${entityId.runtimeType}) $entityId; '
-                  'putsBytes = (${putsBytes.runtimeType}) $putsBytes; '
-                  'removalsBytes = (${removalsBytes.runtimeType}) $removalsBytes'));
-              return;
-            }
-
-            final puts = Uint64List.view(putsBytes.buffer).toList();
-            final removals = Uint64List.view(removalsBytes.buffer).toList();
-
-            // forward the event with entityId, puts & removals
-          }
-      });
-*/
 
 /// Tests only.
 // TODO enable annotation once meta:1.3.0 is out

--- a/objectbox/lib/src/sync.dart
+++ b/objectbox/lib/src/sync.dart
@@ -124,7 +124,6 @@ class SyncClient {
     _cSync = nullptr;
     syncClientsStorage.remove(_store);
     InternalStoreAccess.removeCloseListener(_store, this);
-    syncOrObserversExclusive.unmark(_store);
     checkObx(err);
   }
 
@@ -269,7 +268,6 @@ class Sync {
     if (syncClientsStorage.containsKey(store)) {
       throw Exception('Only one sync client can be active for a store');
     }
-    syncOrObserversExclusive.mark(store);
     final client = SyncClient(store, serverUri, creds);
     syncClientsStorage[store] = client;
     InternalStoreAccess.addCloseListener(store, client, client.close);

--- a/objectbox/lib/src/sync.dart
+++ b/objectbox/lib/src/sync.dart
@@ -151,7 +151,8 @@ class SyncClient {
     final cServerUri = Utf8.toUtf8(serverUri).cast<Int8>();
     try {
       _cSync = checkObxPtr(
-          C.sync_1(_store.ptr, cServerUri), 'failed to create sync client');
+          C.sync_1(InternalStoreAccess.ptr(_store), cServerUri),
+          'failed to create sync client');
     } finally {
       free(cServerUri);
     }
@@ -487,7 +488,7 @@ class _SyncListenerGroup<StreamValueType> {
     return controller.stream;
   }
 
-  // stop() is called when the stream subscription is started or resumed
+  // start() is called when the stream subscription is started or resumed
   void _start() {
     _debugLog('starting');
     assert(finished, 'Starting an unfinished group?!');

--- a/objectbox/lib/src/transaction.dart
+++ b/objectbox/lib/src/transaction.dart
@@ -43,8 +43,8 @@ class Transaction {
   Transaction(this._store, TxMode mode)
       : _isWrite = mode == TxMode.write,
         _cTxn = mode == TxMode.write
-            ? C.txn_write(_store.ptr)
-            : C.txn_read(_store.ptr) {
+            ? C.txn_write(InternalStoreAccess.ptr(_store))
+            : C.txn_read(InternalStoreAccess.ptr(_store)) {
     checkObxPtr(_cTxn, 'failed to create transaction');
   }
 

--- a/objectbox/lib/src/util.dart
+++ b/objectbox/lib/src/util.dart
@@ -5,23 +5,3 @@ import 'sync.dart';
 
 /// Global internal storage of sync clients - one client per store.
 final Map<Store, SyncClient> syncClientsStorage = {};
-
-// Currently, either SyncClient or Observers can be used at the same time.
-// TODO: lift this condition after #142 is fixed.
-class SyncOrObserversExclusive {
-  final _map = <Store, bool>{};
-
-  void mark(Store store) {
-    if (_map.containsKey(store)) {
-      throw Exception(
-          'Using observers/query streams in combination with SyncClient is currently not supported');
-    }
-    _map[store] = true;
-  }
-
-  void unmark(Store store) {
-    _map.remove(store);
-  }
-}
-
-final syncOrObserversExclusive = SyncOrObserversExclusive();

--- a/objectbox/pubspec.yaml
+++ b/objectbox/pubspec.yaml
@@ -37,8 +37,9 @@ ffigen:
   headers:
     entry-points:
       - 'lib/src/bindings/objectbox.h'
+      - 'lib/src/bindings/objectbox-dart.h'
     include-directives:
-      - '**objectbox.h'
+      - '**objectbox*.h'
   functions:
     rename:
       'obx_(.*)': '$1'

--- a/objectbox/pubspec.yaml
+++ b/objectbox/pubspec.yaml
@@ -42,6 +42,7 @@ ffigen:
       - '**objectbox*.h'
   functions:
     rename:
+      'obx_dart_(.*)': 'dartc_$1'
       'obx_(.*)': '$1'
   enums:
     member-rename:

--- a/objectbox/pubspec.yaml
+++ b/objectbox/pubspec.yaml
@@ -5,9 +5,11 @@ homepage: https://objectbox.io
 description: ObjectBox is a super-fast NoSQL ACID compliant object database.
 
 environment:
-  #  sdk: '>=2.12.0-0 <3.0.0'
-  # min 2.7.0 because of ffigen
-  sdk: '>=2.7.0 <3.0.0'
+  # minimum Dart SDK (also see generator/pubspec.yaml)
+  #   v2.9.0 (Flutter v1.20) for package 'dart:ffi' NativeApi.initializeApiDLData
+  #   v1.12.0 (Flutter v1.26) increases DART_API_DL_MAJOR_VERSION, breaking async-callbacks & observers
+  sdk: '>=2.9.0 <3.0.0'
+  # sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   collection: ^1.14.11

--- a/objectbox/test/isolates_test.dart
+++ b/objectbox/test/isolates_test.dart
@@ -88,7 +88,7 @@ void main() {
       final query = env.box.query().build();
       final futureFirst = query.findStream().first; // starts a subscription
       expect(await call(['put', 'Bar']), equals(2));
-      List<TestEntity> found = await futureFirst.timeout(Duration(seconds: 1));
+      List<TestEntity> found = await futureFirst.timeout(defaultTimeout);
       expect(found.length, equals(2));
       expect(found.last.tString, equals('Bar'));
       query.close();

--- a/objectbox/test/isolates_test.dart
+++ b/objectbox/test/isolates_test.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+import 'dart:ffi';
+import 'dart:isolate';
+
+import 'package:objectbox/src/bindings/bindings.dart';
+import 'package:test/test.dart';
+
+import 'entity.dart';
+import 'objectbox.g.dart';
+import 'test_env.dart';
+
+// We want to have types explicit - verifying the return types of functions.
+// ignore_for_file: omit_local_variable_types
+void main() {
+  /// Set up a simple echo isolate with request-response communication.
+  /// This isn't really a test, just an example of how isolates can communicate.
+  test('isolates two-way communication example', () async {
+    var receivePort = ReceivePort();
+    await Isolate.spawn(echoIsolate, receivePort.sendPort);
+
+    Completer sendPortCompleter = Completer<SendPort>();
+    Completer responseCompleter;
+    receivePort.listen((data) {
+      if (data is SendPort) {
+        sendPortCompleter.complete(data);
+      } else {
+        print('Main received: $data');
+        responseCompleter.complete(data);
+      }
+    });
+
+    // Receive the SendPort from the Isolate
+    SendPort sendPort = await sendPortCompleter.future;
+
+    final call = (message) {
+      responseCompleter = Completer<String>();
+      sendPort.send(message);
+      return responseCompleter.future;
+    };
+
+    // Send a message to the isolate
+    expect(await call('hello'), equals('re:hello'));
+    expect(await call('foo'), equals('re:foo'));
+  });
+
+  /// Work with a single store accross multiple isolates
+  test('single store in multiple isolates', () async {
+    var receivePort = ReceivePort();
+    await Isolate.spawn(createDataIsolate, receivePort.sendPort);
+
+    final sendPortCompleter = Completer<SendPort>();
+    Completer<dynamic> responseCompleter;
+    receivePort.listen((data) {
+      if (data is SendPort) {
+        sendPortCompleter.complete(data);
+      } else {
+        print('Main received: $data');
+        responseCompleter.complete(data);
+      }
+    });
+
+    // Receive the SendPort from the Isolate
+    SendPort sendPort = await sendPortCompleter.future;
+
+    final call = (message) {
+      responseCompleter = Completer<dynamic>();
+      sendPort.send(message);
+      return responseCompleter.future;
+    };
+
+    // Pass the store to the isolate
+    final env = TestEnv('isolates');
+    expect(await call(env.store.ptr.address), equals('store set'));
+
+    expect(env.box.isEmpty(), isTrue);
+    expect(await call(['put', 'Foo']), equals(1)); // returns inserted id = 1
+    expect(env.box.get(1).tString, equals('Foo'));
+  });
+}
+
+// Echoes back any received message.
+void echoIsolate(SendPort sendPort) async {
+  // Open the ReceivePort to listen for incoming messages
+  var port = ReceivePort();
+
+  // Send the port where the main isolate can contact us
+  sendPort.send(port.sendPort);
+
+  // Listen for messages
+  await for (var data in port) {
+    // `data` is the message received.
+    print('Isolate received: $data');
+    sendPort.send('re:$data');
+  }
+}
+
+// Creates data in the background, in the [Store] received as the first message.
+void createDataIsolate(SendPort sendPort) async {
+  // Open the ReceivePort to listen for incoming messages
+  var port = ReceivePort();
+
+  // Send the port where the main isolate can contact us
+  sendPort.send(port.sendPort);
+
+  TestEnv env;
+  // Listen for messages
+  await for (var data in port) {
+    if (env == null) {
+      // first message data is Store's C pointer address
+      env = TestEnv.fromPtr(Pointer<OBX_store>.fromAddress(data));
+      sendPort.send('store set');
+    } else {
+      print('Isolate received: $data');
+      if (data is! List) {
+        sendPort.send('unknown message type, list expected');
+      } else {
+        switch (data[0]) {
+          case 'put':
+            final id = env.box.put(TestEntity(tString: data[1]));
+            sendPort.send(id);
+        }
+      }
+    }
+  }
+}

--- a/objectbox/test/isolates_test.dart
+++ b/objectbox/test/isolates_test.dart
@@ -94,7 +94,9 @@ void main() {
       query.close();
     }
 
-    isolate.kill(priority: Isolate.immediate);
+    expect(await call(['close']), equals('done'));
+
+    isolate.kill();
     receivePort.close();
     env.close();
   });
@@ -140,6 +142,13 @@ void createDataIsolate(SendPort sendPort) async {
           case 'put':
             final id = env.box.put(TestEntity(tString: data[1]));
             sendPort.send(id);
+            break;
+          case 'close':
+            env.close();
+            sendPort.send('done');
+            break;
+          default:
+            sendPort.send('unknown message: $data');
         }
       }
     }

--- a/objectbox/test/isolates_test.dart
+++ b/objectbox/test/isolates_test.dart
@@ -49,7 +49,8 @@ void main() {
   /// Work with a single store accross multiple isolates
   test('single store in multiple isolates', () async {
     final receivePort = ReceivePort();
-    final isolate = await Isolate.spawn(createDataIsolate, receivePort.sendPort);
+    final isolate =
+        await Isolate.spawn(createDataIsolate, receivePort.sendPort);
 
     final sendPortCompleter = Completer<SendPort>();
     Completer<dynamic> responseCompleter;
@@ -85,9 +86,9 @@ void main() {
     {
       // verify that query streams (using observers) work fine across isolates
       final queryStream = env.box.query().build().findStream();
+      final futureFirst = queryStream.first; // this starts a subscription
       expect(await call(['put', 'Bar']), equals(2));
-      List<TestEntity> found =
-          await queryStream.first.timeout(Duration(seconds: 1));
+      List<TestEntity> found = await futureFirst.timeout(Duration(seconds: 1));
       expect(found.length, equals(2));
       expect(found.last.tString, equals('Bar'));
     }

--- a/objectbox/test/isolates_test.dart
+++ b/objectbox/test/isolates_test.dart
@@ -85,16 +85,18 @@ void main() {
 
     {
       // verify that query streams (using observers) work fine across isolates
-      final queryStream = env.box.query().build().findStream();
-      final futureFirst = queryStream.first; // this starts a subscription
+      final query = env.box.query().build();
+      final futureFirst = query.findStream().first; // starts a subscription
       expect(await call(['put', 'Bar']), equals(2));
       List<TestEntity> found = await futureFirst.timeout(Duration(seconds: 1));
       expect(found.length, equals(2));
       expect(found.last.tString, equals('Bar'));
+      query.close();
     }
 
     isolate.kill(priority: Isolate.immediate);
     receivePort.close();
+    env.close();
   });
 }
 

--- a/objectbox/test/observer_test.dart
+++ b/objectbox/test/observer_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:objectbox/observable.dart';
 import 'package:test/test.dart';
 
@@ -9,8 +10,7 @@ import 'test_env.dart';
 
 void main() async {
   /*late final*/ TestEnv env;
-  /*late final*/
-  Box<TestEntity> box;
+  /*late final*/ Box<TestEntity> box;
 
   final defaultTimeout = Duration(milliseconds: 100);
 

--- a/objectbox/test/observer_test.dart
+++ b/objectbox/test/observer_test.dart
@@ -12,8 +12,6 @@ void main() async {
   /*late final*/
   Box<TestEntity> box;
 
-  final defaultTimeout = Duration(milliseconds: 100);
-
   final simpleStringItems = () => <String>[
         'One',
         'Two',

--- a/objectbox/test/observer_test.dart
+++ b/objectbox/test/observer_test.dart
@@ -1,6 +1,5 @@
-import 'dart:ffi';
-
-import 'package:objectbox/src/bindings/bindings.dart';
+import 'dart:async';
+import 'package:objectbox/observable.dart';
 import 'package:test/test.dart';
 
 import 'entity.dart';
@@ -8,75 +7,12 @@ import 'entity2.dart';
 import 'objectbox.g.dart';
 import 'test_env.dart';
 
-// ignore_for_file: non_constant_identifier_names
-
-/// Pointer.fromAddress(0) does not fire at all
-Pointer<Void> randomPtr = Pointer.fromAddress(1337);
-
-int callbackSingleTypeCounter = 0;
-
-void callbackSingleType(Pointer<Void> user_data) {
-  expect(user_data.address, randomPtr.address);
-  callbackSingleTypeCounter++;
-}
-
-int callbackAnyTypeCounter = 0;
-
-void callbackAnyType(
-    Pointer<Void> user_data, Pointer<Uint32> mutated_ids, int mutated_count) {
-  expect(user_data.address, randomPtr.address);
-  callbackAnyTypeCounter++;
-}
-
-// dart callback signatures
-typedef Single = void Function(Pointer<Void>);
-typedef Any = void Function(Pointer<Void>, Pointer<Uint32>, int);
-
-class ObservableSingle {
-  static /*late*/ Pointer<OBX_observer> observer;
-  static /*late*/ Single single;
-  Store store;
-
-  ObservableSingle.fromStore(this.store);
-
-  static void _singleCallback(Pointer<Void> user_data) {
-    single(user_data);
-  }
-
-  void observeSingleType(int entityId, Single fn, Pointer<Void> identifier) {
-    single = fn;
-    final callback =
-        Pointer.fromFunction<obx_observer_single_type>(_singleCallback);
-    observer = C.observe_single_type(store.ptr, entityId, callback, identifier);
-  }
-}
-
-class ObservableMany {
-  static /*late*/ Pointer<OBX_observer> observer;
-  static /*late*/ Any any;
-  Store store;
-
-  ObservableMany.fromStore(this.store);
-
-  static void _anyCallback(
-      Pointer<Void> user_data, Pointer<Uint32> mutated_ids, int mutated_count) {
-    any(user_data, mutated_ids, mutated_count);
-  }
-
-  void observe(Any fn, Pointer<Void> identifier) {
-    any = fn;
-    final callback = Pointer.fromFunction<obx_observer>(_anyCallback);
-    observer = C.observe(store.ptr, callback, identifier);
-  }
-}
-
 void main() async {
   /*late final*/ TestEnv env;
-  /*late final*/ Box<TestEntity> box;
-  /*late final*/ Store store;
+  /*late final*/
+  Box<TestEntity> box;
 
-  final testEntityId =
-      getObjectBoxModel().model.findEntityByName('TestEntity').id.id;
+  final defaultTimeout = Duration(milliseconds: 100);
 
   final simpleStringItems = () => <String>[
         'One',
@@ -95,82 +31,85 @@ void main() async {
   setUp(() {
     env = TestEnv('observers');
     box = env.box;
-    store = env.store;
-  });
-
-  /// Non static function can't be used for ffi, but you can call a dynamic function
-  /// aka closure inside a static function
-  //  void callbackAnyTypeNonStatic(Pointer<Void> user_data, Pointer<Uint32> mutated_ids, int mutated_count) {
-  //    expect(user_data.address, 0);
-  //    expect(mutated_count, 1);
-  //  }
-
-  test('Observe any entity with class member callback', () async {
-    final o = ObservableMany.fromStore(store);
-    var putCount = 0;
-    o.observe((Pointer<Void> user_data, Pointer<Uint32> mutated_ids,
-        int mutated_count) {
-      expect(user_data.address, randomPtr.address);
-      putCount++;
-    }, randomPtr);
-
-    box.putMany(simpleStringItems());
-    simpleStringItems().forEach((i) => box.put(i));
-    simpleNumberItems().forEach((i) => box.put(i));
-
-    C.observer_close(ObservableMany.observer);
-    expect(putCount, 13);
-  });
-
-  test('Observe a single entity with class member callback', () async {
-    final o = ObservableSingle.fromStore(store);
-    var putCount = 0;
-    o.observeSingleType(testEntityId, (Pointer<Void> user_data) {
-      putCount++;
-    }, randomPtr);
-
-    box.putMany(simpleStringItems());
-    simpleStringItems().forEach((i) => box.put(i));
-    simpleNumberItems().forEach((i) => box.put(i));
-
-    C.observer_close(ObservableSingle.observer);
-    expect(putCount, 13);
-  });
-
-  test('Observe any entity with static callback', () async {
-    final callback = Pointer.fromFunction<obx_observer>(callbackAnyType);
-    final observer = C.observe(store.ptr, callback, Pointer.fromAddress(1337));
-
-    box.putMany(simpleStringItems());
-
-    box.remove(1);
-
-    // update value
-    final entity2 = box.get(2);
-    entity2.tString = 'Dva';
-    box.put(entity2);
-
-    final box2 = Box<TestEntity2>(store);
-    box2.put(TestEntity2());
-    box2.remove(1);
-    box2.put(TestEntity2());
-
-    expect(callbackAnyTypeCounter, 6);
-    C.observer_close(observer);
   });
 
   test('Observe single entity', () async {
-    final callback =
-        Pointer.fromFunction<obx_observer_single_type>(callbackSingleType);
-    final observer =
-        C.observe_single_type(store.ptr, testEntityId, callback, randomPtr);
+    Completer completer;
+    var expectedEvents = 0;
 
+    final stream = env.store.subscribe<TestEntity>();
+    final subscription = stream.listen((_) {
+      print('TestEntity updated');
+      expectedEvents--;
+      if (expectedEvents == 0) {
+        completer.complete();
+      }
+    });
+
+    // expect two events after one put() and one putMany()
+    expectedEvents = 2;
+    completer = Completer();
+    box.put(simpleStringItems().first);
+    Box<TestEntity2>(env.store).put(TestEntity2());
     box.putMany(simpleStringItems());
-    simpleStringItems().forEach((i) => box.put(i));
-    simpleNumberItems().forEach((i) => box.put(i));
+    await completer.future.timeout(defaultTimeout);
+    expect(expectedEvents, 0);
 
-    expect(callbackSingleTypeCounter, 13);
-    C.observer_close(observer);
+    // cancel the subscription
+    await subscription.cancel();
+
+    // make sure there are no more events after cancelling
+    expectedEvents = 1;
+    completer = Completer();
+    box.put(simpleStringItems().first);
+    expect(completer.future.timeout(defaultTimeout),
+        throwsA(isA<TimeoutException>()));
+    expect(expectedEvents, 1); // note: unchanged, no events received anymore
+  });
+
+  test('Observe multiple entities', () async {
+    Completer completer;
+    var expectedEvents = 0;
+    var typesUpdates = <Type, int>{}; // number of events per entity type
+
+    final stream = env.store.subscribeAll();
+
+    final subscription = stream.listen((entityType) {
+      print('Entity updated: $entityType');
+      expectedEvents--;
+
+      if (typesUpdates[entityType] == null) {
+        typesUpdates[entityType] = 0;
+      }
+      typesUpdates[entityType]++;
+
+      if (expectedEvents == 0) {
+        completer.complete();
+      }
+    });
+
+    // expect two events after one put() and one putMany()
+    expectedEvents = 3;
+    completer = Completer();
+    box.put(simpleStringItems().first);
+    Box<TestEntity2>(env.store).put(TestEntity2());
+    box.putMany(simpleStringItems());
+    await completer.future.timeout(defaultTimeout);
+    expect(expectedEvents, 0);
+    expect(typesUpdates.keys, unorderedEquals([TestEntity, TestEntity2]));
+    expect(typesUpdates[TestEntity], 2);
+    expect(typesUpdates[TestEntity2], 1);
+
+    // cancel the subscription
+    await subscription.cancel();
+
+    // make sure there are no more events after cancelling
+    expectedEvents = 1;
+    completer = Completer();
+    box.put(simpleStringItems().first);
+    expect(completer.future.timeout(defaultTimeout),
+        throwsA(isA<TimeoutException>()));
+    expect(expectedEvents, 1); // note: unchanged, no events received anymore
   });
 
   tearDown(() {

--- a/objectbox/test/observer_test.dart
+++ b/objectbox/test/observer_test.dart
@@ -125,26 +125,26 @@ void main() async {
 
       // triggers when listening
       completer = Completer();
-      box.put(simpleStringItems[0]);
+      box.put(simpleStringItems().first);
       await completer.future.timeout(defaultTimeout);
 
       // won't trigger when paused
       subscription.pause();
       completer = Completer();
-      box.put(simpleStringItems[0]);
+      box.put(simpleStringItems().first);
       expect(completer.future.timeout(defaultTimeout),
           throwsA(isA<TimeoutException>()));
 
       // triggers when resumed
       subscription.resume();
       completer = Completer();
-      box.put(simpleStringItems[0]);
+      box.put(simpleStringItems().first);
       await completer.future.timeout(defaultTimeout);
 
       // won't trigger when cancelled
       await subscription.cancel();
       completer = Completer();
-      box.put(simpleStringItems[0]);
+      box.put(simpleStringItems().first);
       expect(completer.future.timeout(defaultTimeout),
           throwsA(isA<TimeoutException>()));
     };

--- a/objectbox/test/observer_test.dart
+++ b/objectbox/test/observer_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:objectbox/observable.dart';
 import 'package:test/test.dart';
 
 import 'entity.dart';
@@ -10,7 +9,8 @@ import 'test_env.dart';
 
 void main() async {
   /*late final*/ TestEnv env;
-  /*late final*/ Box<TestEntity> box;
+  /*late final*/
+  Box<TestEntity> box;
 
   final defaultTimeout = Duration(milliseconds: 100);
 
@@ -23,11 +23,6 @@ void main() async {
         'Six'
       ].map((s) => TestEntity(tString: s)).toList().cast<TestEntity>();
 
-  final simpleNumberItems = () => [1, 2, 3, 4, 5, 6]
-      .map((s) => TestEntity(tInt: s))
-      .toList()
-      .cast<TestEntity>();
-
   setUp(() {
     env = TestEnv('observers');
     box = env.box;
@@ -38,7 +33,7 @@ void main() async {
   });
 
   test('Observe single entity', () async {
-    Completer completer;
+    Completer<void> completer;
     var expectedEvents = 0;
 
     final stream = env.store.subscribe<TestEntity>();
@@ -72,7 +67,7 @@ void main() async {
   });
 
   test('Observe multiple entities', () async {
-    Completer completer;
+    Completer<void> completer;
     var expectedEvents = 0;
     var typesUpdates = <Type, int>{}; // number of events per entity type
 
@@ -100,7 +95,7 @@ void main() async {
     box.putMany(simpleStringItems());
     await completer.future.timeout(defaultTimeout);
     expect(expectedEvents, 0);
-    expect(typesUpdates.keys, unorderedEquals([TestEntity, TestEntity2]));
+    expect(typesUpdates.keys, sameAsList<Type>([TestEntity, TestEntity2]));
     expect(typesUpdates[TestEntity], 2);
     expect(typesUpdates[TestEntity2], 1);
 
@@ -118,8 +113,8 @@ void main() async {
 
   test('Observer pause/resume', () async {
     final testPauseResume = (Stream stream) async {
-      Completer completer;
-      final subscription = stream.listen((_) {
+      Completer<void> completer;
+      final subscription = stream.listen((dynamic _) {
         completer.complete();
       });
 

--- a/objectbox/test/observer_test.dart
+++ b/objectbox/test/observer_test.dart
@@ -85,7 +85,7 @@ void main() async {
       }
     });
 
-    // expect two events after one put() and one putMany()
+    // expect three events: two puts() (separate entities), one putMany()
     expectedEvents = 3;
     completer = Completer();
     box.put(simpleStringItems().first);
@@ -128,7 +128,7 @@ void main() async {
       expect(completer.future.timeout(defaultTimeout),
           throwsA(isA<TimeoutException>()));
 
-      // triggers when resumed
+      // triggers when resumed (Note: no buffering of previous events)
       subscription.resume();
       completer = Completer();
       box.put(simpleStringItems().first);

--- a/objectbox/test/query_test.dart
+++ b/objectbox/test/query_test.dart
@@ -9,7 +9,8 @@ import 'test_env.dart';
 
 void main() {
   /*late final*/ TestEnv env;
-  /*late final*/ Box<TestEntity> box;
+  /*late final*/
+  Box<TestEntity> box;
 
   setUp(() {
     env = TestEnv('query');
@@ -240,8 +241,8 @@ void main() {
     final q3 = box.query(text.equals("can't find this")).build();
     final result3 = q3.findIds();
 
-    expect(result0, unorderedEqualsInts([2, 3, 4, 5, 6, 7]));
-    expect(result2, unorderedEqualsInts([7]));
+    expect(result0, sameAsList([2, 3, 4, 5, 6, 7]));
+    expect(result2, sameAsList([7]));
     expect(result3.isEmpty, isTrue);
 
     q0.close();

--- a/objectbox/test/relations_test.dart
+++ b/objectbox/test/relations_test.dart
@@ -324,22 +324,19 @@ void main() {
       expect(b[2].tString, 'not referenced');
 
       final strings = (TestEntity e) => e.tString;
-      expect(b[0].testEntities.map(strings), unorderedEqualsStrings(['foo']));
-      expect(b[1].testEntities.map(strings),
-          unorderedEqualsStrings(['bar', 'bar2']));
+      expect(b[0].testEntities.map(strings), sameAsList(['foo']));
+      expect(b[1].testEntities.map(strings), sameAsList(['bar', 'bar2']));
       expect(b[2].testEntities.length, isZero);
 
       // Update an existing target.
       b[1].testEntities.add(env.box.get(1)); // foo
-      expect(b[1].testEntities.map(strings),
-          unorderedEqualsStrings(['foo', 'bar', 'bar2']));
+      expect(
+          b[1].testEntities.map(strings), sameAsList(['foo', 'bar', 'bar2']));
       b[1].testEntities.removeWhere((e) => e.tString == 'bar');
-      expect(b[1].testEntities.map(strings),
-          unorderedEqualsStrings(['foo', 'bar2']));
+      expect(b[1].testEntities.map(strings), sameAsList(['foo', 'bar2']));
       boxB.put(b[1]);
       b[1] = boxB.get(b[1].id);
-      expect(b[1].testEntities.map(strings),
-          unorderedEqualsStrings(['foo', 'bar2']));
+      expect(b[1].testEntities.map(strings), sameAsList(['foo', 'bar2']));
 
       // Insert a new target, already with some "source" entities pointing to it.
       var newB = RelatedEntityB();
@@ -353,11 +350,11 @@ void main() {
       expect(env.box.get(4).tString, equals('newly created from B'));
       newB = boxB.get(newB.id);
       expect(newB.testEntities.map(strings),
-          unorderedEqualsStrings(['foo', 'newly created from B']));
+          sameAsList(['foo', 'newly created from B']));
 
       // The previous put also affects b[1], 'foo' is not related anymore.
       b[1] = boxB.get(b[1].id);
-      expect(b[1].testEntities.map(strings), unorderedEqualsStrings(['bar2']));
+      expect(b[1].testEntities.map(strings), sameAsList(['bar2']));
     });
 
     test('query', () {
@@ -394,22 +391,19 @@ void main() {
       expect(a[2].tInt, 3);
 
       final strings = (TestEntity e) => e.tString;
-      expect(a[0].testEntities.map(strings), unorderedEqualsStrings(['foo']));
-      expect(a[1].testEntities.map(strings),
-          unorderedEqualsStrings(['bar', 'bar2']));
+      expect(a[0].testEntities.map(strings), sameAsList(['foo']));
+      expect(a[1].testEntities.map(strings), sameAsList(['bar', 'bar2']));
       expect(a[2].testEntities.length, isZero);
 
       // Update an existing target.
       a[1].testEntities.add(env.box.get(1)); // foo
-      expect(a[1].testEntities.map(strings),
-          unorderedEqualsStrings(['foo', 'bar', 'bar2']));
+      expect(
+          a[1].testEntities.map(strings), sameAsList(['foo', 'bar', 'bar2']));
       a[1].testEntities.removeWhere((e) => e.tString == 'bar');
-      expect(a[1].testEntities.map(strings),
-          unorderedEqualsStrings(['foo', 'bar2']));
+      expect(a[1].testEntities.map(strings), sameAsList(['foo', 'bar2']));
       boxA.put(a[1]);
       a[1] = boxA.get(a[1].id);
-      expect(a[1].testEntities.map(strings),
-          unorderedEqualsStrings(['foo', 'bar2']));
+      expect(a[1].testEntities.map(strings), sameAsList(['foo', 'bar2']));
 
       // Insert a new target with some "source" entities pointing to it.
       var newA = RelatedEntityA(tInt: 4);
@@ -423,11 +417,10 @@ void main() {
       expect(env.box.get(4).tString, equals('newly created from A'));
       newA = boxA.get(newA.id);
       expect(newA.testEntities.map(strings),
-          unorderedEqualsStrings(['foo', 'newly created from A']));
+          sameAsList(['foo', 'newly created from A']));
 
       // The previous put also affects TestEntity(foo) - added target (tInt=4).
-      expect(
-          env.box.get(1).relManyA.map(toInt), unorderedEqualsInts([1, 2, 4]));
+      expect(env.box.get(1).relManyA.map(toInt), sameAsList([1, 2, 4]));
     });
 
     test('query', () {

--- a/objectbox/test/stream_test.dart
+++ b/objectbox/test/stream_test.dart
@@ -21,7 +21,7 @@ void main() {
 
   // Yield execution to other isolates.
   //
-  // We need to do this to receive an even in the stream before processing
+  // We need to do this to receive an event in the stream before processing
   // the remainder of the test case.
   final yieldExecution = () async => await Future.delayed(Duration.zero);
 

--- a/objectbox/test/stream_test.dart
+++ b/objectbox/test/stream_test.dart
@@ -19,6 +19,12 @@ void main() {
     box = env.box;
   });
 
+  // Yield execution to other isolates.
+  //
+  // We need to do this to receive an even in the stream before processing
+  // the remainder of the test case.
+  final yieldExecution = () async => await Future.delayed(Duration.zero);
+
   test('Subscribe to stream of entities', () async {
     final result = <String>[];
     final text = TestEntity_.tString;
@@ -32,16 +38,14 @@ void main() {
 
     box.put(TestEntity(tString: 'Hello world'));
 
-    // The delay is here to ensure that the callback execution is executed
-    // sequentially, otherwise the testing framework's execution  will be
-    // prioritized (for some reason), before any callback.
-    await Future<dynamic>.delayed(Duration(seconds: 0));
+    await yieldExecution();
 
     box.putMany(<TestEntity>[
       TestEntity(tString: 'Goodbye'),
       TestEntity(tString: 'for now')
     ]);
-    await Future<dynamic>.delayed(Duration(seconds: 0));
+
+    await yieldExecution();
 
     expect(result, ['Hello world', 'for now, Goodbye, Hello world']);
 
@@ -60,14 +64,16 @@ void main() {
     });
 
     box.put(TestEntity(tString: 'Hello world'));
-    await Future<dynamic>.delayed(Duration(seconds: 0));
+
+    await yieldExecution();
 
     // idem, see above
     box.putMany(<TestEntity>[
       TestEntity(tString: 'Goodbye'),
       TestEntity(tString: 'for now')
     ]);
-    await Future<dynamic>.delayed(Duration(seconds: 0));
+
+    await yieldExecution();
 
     expect(result, [1, 3]);
 
@@ -99,7 +105,7 @@ void main() {
     final t2 = TestEntity2();
     box2.put(t2);
 
-    await Future<dynamic>.delayed(Duration(seconds: 0));
+    await yieldExecution();
     expect(counter1, 0);
     expect(counter2, 1);
 
@@ -107,7 +113,7 @@ void main() {
     final t1 = TestEntity();
     box.put(t1);
 
-    await Future<dynamic>.delayed(Duration(seconds: 0));
+    await yieldExecution();
     expect(counter1, 1);
     expect(counter2, 1);
 
@@ -115,7 +121,7 @@ void main() {
     final ts1 = [1, 2, 3].map((i) => TestEntity(tInt: i)).toList();
     box.putMany(ts1);
 
-    await Future<dynamic>.delayed(Duration(seconds: 0));
+    await yieldExecution();
     expect(counter1, 2);
     expect(counter2, 1);
 
@@ -123,7 +129,7 @@ void main() {
     final ts2 = [1, 2, 3].map((i) => TestEntity2()).toList();
     box2.putMany(ts2);
 
-    await Future<dynamic>.delayed(Duration(seconds: 0));
+    await yieldExecution();
     expect(counter1, 2);
     expect(counter2, 2);
 

--- a/objectbox/test/stream_test.dart
+++ b/objectbox/test/stream_test.dart
@@ -19,12 +19,6 @@ void main() {
     box = env.box;
   });
 
-  // Yield execution to other isolates.
-  //
-  // We need to do this to receive an event in the stream before processing
-  // the remainder of the test case.
-  final yieldExecution = () async => await Future.delayed(Duration.zero);
-
   test('Subscribe to stream of entities', () async {
     final result = <String>[];
     final text = TestEntity_.tString;

--- a/objectbox/test/stream_test.dart
+++ b/objectbox/test/stream_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:test/test.dart';
 
 import 'entity.dart';

--- a/objectbox/test/sync_test.dart
+++ b/objectbox/test/sync_test.dart
@@ -264,6 +264,23 @@ void main() {
 
         client.close();
       });
+
+      test('SyncClient listeners: completion', () async {
+        final client = loggedInClient(store);
+        expect(env.box.isEmpty(), isTrue);
+        int id = env.box.put(TestEntity(tLong: 100));
+
+        // Note: wait for the client to finish sending to the server.
+        // There's currently no other way to recognize this.
+        sleep(Duration(milliseconds: 100));
+        client.close();
+
+        final client2 = loggedInClient(env2.store);
+        await client2.completionEvents.first.timeout(Duration(seconds: 1));
+        client2.close();
+
+        expect(env2.box.get(1) /*!*/ .tLong, 100);
+      });
     },
         skip: SyncServer.isAvailable()
             ? null

--- a/objectbox/test/sync_test.dart
+++ b/objectbox/test/sync_test.dart
@@ -59,24 +59,6 @@ void main() {
   if (Sync.isAvailable()) {
     // TESTS to run when SYNC is available
 
-    group('Circumvent issue #142 - async callbacks error', () {
-      final error = throwsA(predicate((Exception e) => e.toString().contains(
-          'Using observers/query streams in combination with SyncClient is currently not supported')));
-
-      test('Must not start an Observer when SyncClient is active', () {
-        createClient(store);
-        expect(() => env.box.query().build().findStream(), error);
-      });
-
-      test('Must not start SyncClient when an Observer is active', () {
-        final error = throwsA(predicate((Exception e) => e.toString().contains(
-            'Using observers/query streams in combination with SyncClient is currently not supported')));
-
-        createClient(store);
-        expect(() => env.box.query().build().findStream(), error);
-      });
-    });
-
     test('SyncClient lifecycle', () {
       expect(store.syncClient(), isNull);
 

--- a/objectbox/test/test_env.dart
+++ b/objectbox/test/test_env.dart
@@ -48,3 +48,9 @@ bool waitUntil(bool Function() predicate, {int timeoutMs = 1000}) {
 Matcher unorderedEqualsStrings(List<String> list) => unorderedEquals(list);
 
 Matcher unorderedEqualsInts(List<int> list) => unorderedEquals(list);
+
+// Yield execution to other isolates.
+//
+// We need to do this to receive an event in the stream before processing
+// the remainder of the test case.
+final yieldExecution = () async => await Future.delayed(Duration.zero);

--- a/objectbox/test/test_env.dart
+++ b/objectbox/test/test_env.dart
@@ -1,6 +1,8 @@
+import 'dart:ffi';
 import 'dart:io';
 
 import 'package:test/test.dart';
+import 'package:objectbox/src/bindings/bindings.dart';
 
 import 'entity.dart';
 import 'objectbox.g.dart';
@@ -15,13 +17,17 @@ class TestEnv {
     return TestEnv._(dir, Store(getObjectBoxModel(), directory: dir.path));
   }
 
+  TestEnv.fromPtr(Pointer<OBX_store> cStore)
+      : dir = null,
+        store = Store.fromPtr(getObjectBoxModel(), cStore);
+
   TestEnv._(this.dir, this.store);
 
   Box<TestEntity> get box => store.box();
 
   void close() {
     store.close();
-    if (dir.existsSync()) dir.deleteSync(recursive: true);
+    if (dir != null && dir.existsSync()) dir.deleteSync(recursive: true);
   }
 }
 

--- a/objectbox/test/test_env.dart
+++ b/objectbox/test/test_env.dart
@@ -27,7 +27,9 @@ class TestEnv {
 
   void close() {
     store.close();
-    if (dir != null && dir.existsSync()) dir.deleteSync(recursive: true);
+    if (dir != null && dir /*!*/ .existsSync()) {
+      dir /*!*/ .deleteSync(recursive: true);
+    }
   }
 }
 

--- a/objectbox/test/test_env.dart
+++ b/objectbox/test/test_env.dart
@@ -33,13 +33,14 @@ class TestEnv {
   }
 }
 
-/// "Busy-waits" until the predicate returns true.
-bool waitUntil(bool Function() predicate, {int timeoutMs = 1000}) {
-  var success = false;
-  final until = DateTime.now().millisecondsSinceEpoch + timeoutMs;
+const defaultTimeout = Duration(milliseconds: 1000);
 
-  while (!(success = predicate()) &&
-      until > DateTime.now().millisecondsSinceEpoch) {
+/// "Busy-waits" until the predicate returns true.
+bool waitUntil(bool Function() predicate, {Duration timeout = defaultTimeout}) {
+  var success = false;
+  final until = DateTime.now().add(timeout);
+
+  while (!(success = predicate()) && until.isAfter(DateTime.now())) {
     sleep(Duration(milliseconds: 1));
   }
   return success;

--- a/objectbox/test/test_env.dart
+++ b/objectbox/test/test_env.dart
@@ -45,6 +45,9 @@ bool waitUntil(bool Function() predicate, {int timeoutMs = 1000}) {
   return success;
 }
 
+/// same as package:test unorderedEquals() but statically typed
+Matcher sameAsList<T>(List<T> list) => unorderedEquals(list);
+
 Matcher unorderedEqualsStrings(List<String> list) => unorderedEquals(list);
 
 Matcher unorderedEqualsInts(List<int> list) => unorderedEquals(list);
@@ -53,4 +56,4 @@ Matcher unorderedEqualsInts(List<int> list) => unorderedEquals(list);
 //
 // We need to do this to receive an event in the stream before processing
 // the remainder of the test case.
-final yieldExecution = () async => await Future.delayed(Duration.zero);
+final yieldExecution = () async => await Future<void>.delayed(Duration.zero);

--- a/objectbox/test/test_env.dart
+++ b/objectbox/test/test_env.dart
@@ -1,8 +1,7 @@
-import 'dart:ffi';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:test/test.dart';
-import 'package:objectbox/src/bindings/bindings.dart';
 
 import 'entity.dart';
 import 'objectbox.g.dart';
@@ -16,10 +15,6 @@ class TestEnv {
     if (dir.existsSync()) dir.deleteSync(recursive: true);
     return TestEnv._(dir, Store(getObjectBoxModel(), directory: dir.path));
   }
-
-  TestEnv.fromPtr(Pointer<OBX_store> cStore)
-      : dir = null,
-        store = Store.fromPtr(getObjectBoxModel(), cStore);
 
   TestEnv._(this.dir, this.store);
 

--- a/objectbox/test/test_env.dart
+++ b/objectbox/test/test_env.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:test/test.dart';
 
@@ -43,10 +42,6 @@ bool waitUntil(bool Function() predicate, {Duration timeout = defaultTimeout}) {
 
 /// same as package:test unorderedEquals() but statically typed
 Matcher sameAsList<T>(List<T> list) => unorderedEquals(list);
-
-Matcher unorderedEqualsStrings(List<String> list) => unorderedEquals(list);
-
-Matcher unorderedEqualsInts(List<int> list) => unorderedEquals(list);
 
 // Yield execution to other isolates.
 //

--- a/objectbox/tool/valgrind.sh
+++ b/objectbox/tool/valgrind.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Note: when you see the process seemingly stuck after printing "All tests passed!", it's because dart2native produced
+#       binaries will wait for any background isolates to finish before stopping the process.
+#       For example, the following code has the issue: `HttpClient().get(...)`
+#       while `final httpClient = HttpClient(); httpClient.get(...); httpClient.close(force: true);` works fine.
+
 root=$(
   cd "$(dirname "$0")/.."
   pwd -P
@@ -17,20 +22,18 @@ fi
 testDir="${root}/build/test/valgrind"
 rm -rf "${testDir}"
 mkdir -pv "${testDir}"
-cd "${testDir}" || exit 1
-
 
 function testWithValgrind() {
   echo "Running $1 with valgrind"
-
-  dart2native "${root}/test/${1}" --output ./test --verbose
+  testExe="${testDir}/${1%.*}"
+  dart2native "${root}/test/${1}" --output "${testExe}" --verbose
   valgrind \
     --leak-check=full \
     --error-exitcode=1 \
     --show-mismatched-frees=no \
     --show-possibly-lost=no \
     --errors-for-leak-kinds=definite \
-    ./test
+    "${testExe}"
 
   echo "$1 successful - no errors reported by valgrind"
   echo "--------------------------------------------------------------------------------"
@@ -39,12 +42,10 @@ function testWithValgrind() {
 if [[ "$#" -gt "0" ]]; then
   testWithValgrind "${1}_test.dart"
 else
-  for file in "${root}/test/"*_test.dart
-  do
-    testWithValgrind $(basename $file)
+  for file in "${root}/test/"*_test.dart; do
+    testWithValgrind "$(basename "$file")"
   done
 fi
 
 echo "Test passed, cleaning up"
-cd "${root}" || exit 1
 rm -rf "${testDir}"

--- a/sync_flutter_libs/android/build.gradle
+++ b/sync_flutter_libs/android/build.gradle
@@ -12,5 +12,5 @@ android {
 
 dependencies {
     // https://bintray.com/objectbox/objectbox/io.objectbox%3Aobjectbox-android
-    implementation "io.objectbox:objectbox-android:2.8.0-sync"
+    implementation "io.objectbox:objectbox-android:2.9.0-sync"
 }

--- a/sync_flutter_libs/ios/download-framework.sh
+++ b/sync_flutter_libs/ios/download-framework.sh
@@ -3,23 +3,23 @@ set -euo pipefail
 
 # NOTE: run this script before publishing
 
-echo "Sync-enabled objectbox-swift isn't released yet"
-exit 1
-
 # https://github.com/objectbox/objectbox-swift/releases/
-obxSwiftVersion="1.4.1"
+obxSwiftVersion="1.5.0-sync-rc5"
 
 dir=$(dirname "$0")
 
-url="https://github.com/objectbox/objectbox-swift/releases/download/v${obxSwiftVersion}/ObjectBox-framework-${obxSwiftVersion}.zip"
+#url="https://github.com/objectbox/objectbox-swift/releases/download/v${obxSwiftVersion}/ObjectBox-framework-${obxSwiftVersion}.zip"
+url="https://github.com/objectbox/objectbox-swift-spec-staging/releases/download/v1.x/ObjectBox-xcframework-${obxSwiftVersion}.zip"
 zip="${dir}/fw.zip"
 
 curl --location --fail --output "${zip}" "${url}"
 
+frameworkPath=Carthage/Build/ObjectBox.xcframework/ios-arm64/ObjectBox.framework
+
 rm -rf "${dir}/Carthage"
 unzip "${zip}" -d "${dir}" \
-  "Carthage/Build/iOS/ObjectBox.framework/Headers/*" \
-  "Carthage/Build/iOS/ObjectBox.framework/ObjectBox" \
-  "Carthage/Build/iOS/ObjectBox.framework/Info.plist"
+  "${frameworkPath}/Headers/*" \
+  "${frameworkPath}/ObjectBox" \
+  "${frameworkPath}/Info.plist"
 
 rm "${zip}"

--- a/sync_flutter_libs/pubspec.yaml
+++ b/sync_flutter_libs/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://objectbox.io
 description: ObjectBox is a super-fast NoSQL ACID compliant object database. This package contains flutter runtime libraries for ObjectBox, including ObjectBox Sync.
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
-  flutter: ">=1.12.0 <2.0.0"
+  sdk: ">=2.9.0 <3.0.0"
+  flutter: ">=1.20.0 <2.0.0"
 
 dependencies:
   # This is here just to ensure compatibility between objectbox-dart code and the libraries used

--- a/tool/publish.sh
+++ b/tool/publish.sh
@@ -4,8 +4,7 @@
 
 echo "Downloading iOS dependencies for package flutter libs"
 "${root}"/flutter_libs/ios/download-framework.sh
-# TODO enable once objectbox-swift with Sync is released
-#"${root}"/sync_flutter_libs/ios/download-framework.sh
+"${root}"/sync_flutter_libs/ios/download-framework.sh
 
 echo "Commenting-out Carthage in .gitignore in flutter libs"
 update flutter_libs/ios/.gitignore "s/^Carthage/#Carthage/g"


### PR DESCRIPTION
The changes necessary are pretty simple - just allow creating Store from an existing `OBX_Store` C pointer and pass that between isolates. Any ideas how to improve/simplify that for users? I don't really know the most common isolates' usage patterns in Dart/Flutter yet so I'm open to suggestions.

However, to get it working, we had to do some custom stuff to send handle async callbacks (issue  #142) - objectbox-c now (v0.12+) includes dart-specific functionality to connect to a dart runtime and send callback data over streams. This required a rework of the observers.

Besides the above, this PR also implements sync listeners.