### PR TITLE
Null-safety preparation

### DIFF
--- a/example/flutter/objectbox_demo/lib/main.dart
+++ b/example/flutter/objectbox_demo/lib/main.dart
@@ -81,7 +81,7 @@ class ViewModel {
 
 class _MyHomePageState extends State<MyHomePage> {
   final _noteInputController = TextEditingController();
-  final _listController = StreamController<List<Note>>(sync:true);
+  final _listController = StreamController<List<Note>>(sync: true);
   Stream<List<Note>> _stream;
   ViewModel _vm;
 

--- a/generator/integration-tests/shared-pubspec.yaml
+++ b/generator/integration-tests/shared-pubspec.yaml
@@ -1,5 +1,8 @@
 name: objectbox_generator_test
 
+environment:
+  sdk: ">=2.5.0 <3.0.0"
+
 dependencies:
   objectbox: any
 

--- a/generator/lib/src/code_builder.dart
+++ b/generator/lib/src/code_builder.dart
@@ -77,7 +77,7 @@ class CodeBuilder extends Builder {
           ModelInfo.fromMap(json.decode(await buildStep.readAsString(jsonId)));
     } else {
       log.warning('Creating model: ${jsonId.path}');
-      model = ModelInfo.createDefault();
+      model = ModelInfo();
     }
 
     // merge existing model and annotated model that was just read, then write new final model to file

--- a/generator/lib/src/code_builder.dart
+++ b/generator/lib/src/code_builder.dart
@@ -152,7 +152,6 @@ class CodeBuilder extends Builder {
       log.info('Found new entity ${entity.name}');
       // in case the entity is created (i.e. when its given UID or name that does not yet exist), we are done, as nothing needs to be merged
       entityInModel = modelInfo.addEntity(entity);
-
     } else {
       entityInModel.name = entity.name;
       entityInModel.flags = entity.flags;
@@ -161,12 +160,13 @@ class CodeBuilder extends Builder {
       entity.properties.forEach((p) => mergeProperty(entityInModel, p));
 
       // then remove all properties not present anymore in readEntity
-      entityInModel.properties
+      final missingProps = entityInModel.properties
           .where((p) => entity.findSameProperty(p) == null)
-          .forEach((p) {
+          .toList(growable: false);
+
+      missingProps.forEach((p) {
         log.warning(
-            'Property ${entity.name}.${p.name}(${p.id
-                .toString()}) not found in the code, removing from the model');
+            'Property ${entity.name}.${p.name}(${p.id.toString()}) not found in the code, removing from the model');
         entityInModel.removeProperty(p);
       });
     }

--- a/generator/lib/src/code_chunks.dart
+++ b/generator/lib/src/code_chunks.dart
@@ -30,7 +30,7 @@ class CodeChunks {
     final name = entity.name;
     return """
       EntityDefinition<${name}>(
-        model: model.findEntityByUid(${entity.id.uid}, required: true)/*!*/,
+        model: model.getEntityByUid(${entity.id.uid}),
         reader: ($name inst) => {
           ${entity.properties.map((p) => "'${p.name}': inst.${p.name}").join(",\n")}
         },

--- a/generator/lib/src/code_chunks.dart
+++ b/generator/lib/src/code_chunks.dart
@@ -30,7 +30,7 @@ class CodeChunks {
     final name = entity.name;
     return """
       EntityDefinition<${name}>(
-        model: model.findEntityByUid(${entity.id.uid}),
+        model: model.findEntityByUid(${entity.id.uid}, required: true)/*!*/,
         reader: ($name inst) => {
           ${entity.properties.map((p) => "'${p.name}': inst.${p.name}").join(",\n")}
         },

--- a/generator/lib/src/entity_resolver.dart
+++ b/generator/lib/src/entity_resolver.dart
@@ -54,7 +54,7 @@ class EntityResolver extends Builder {
     var element = elementBare as ClassElement;
 
     // process basic entity (note that allModels.createEntity is not used, as the entity will be merged)
-    final entity = ModelEntity(IdUid.empty(), null, element.name, 0, [], null);
+    final entity = ModelEntity(IdUid.empty(), element.name, null);
     var entityUid = annotation.read('uid');
     if (entityUid != null && !entityUid.isNull) {
       entity.id.uid = entityUid.intValue;

--- a/generator/test.sh
+++ b/generator/test.sh
@@ -15,10 +15,10 @@ function runTestFile() {
     # build before each step, except for "0.dart"
     if [ "${1}" != "0" ]; then
       echo "Running build_runner before ${file}"
-      pub run build_runner build
+      dart pub run build_runner build
     fi
     echo "Running ${file}"
-    pub run test "${file}"
+    dart test "${file}"
   fi
 }
 
@@ -31,7 +31,7 @@ function runTestCase() {
 
   cd "${testCase}"
 
-  pub get
+  dart pub get
   for i in {0..9}; do
     runTestFile $i
   done

--- a/lib/integration_test.dart
+++ b/lib/integration_test.dart
@@ -17,11 +17,11 @@ class IntegrationTest {
 
   static void model() {
     // create a model with a single entity and a single property
-    final modelInfo = ModelInfo.createDefault();
+    final modelInfo = ModelInfo();
     final property = ModelProperty(
         IdUid(1, int64_max - 1), 'id', OBXPropertyType.Long, 0, null);
     final entity =
-        ModelEntity(IdUid(1, int64_max), null, 'entity', 0, [], modelInfo);
+        ModelEntity(IdUid(1, int64_max), 'entity', modelInfo);
     property.entity = entity;
     entity.properties.add(property);
     entity.lastPropertyId = property.id;

--- a/lib/integration_test.dart
+++ b/lib/integration_test.dart
@@ -20,8 +20,7 @@ class IntegrationTest {
     final modelInfo = ModelInfo();
     final property = ModelProperty(
         IdUid(1, int64_max - 1), 'id', OBXPropertyType.Long, 0, null);
-    final entity =
-        ModelEntity(IdUid(1, int64_max), 'entity', modelInfo);
+    final entity = ModelEntity(IdUid(1, int64_max), 'entity', modelInfo);
     property.entity = entity;
     entity.properties.add(property);
     entity.lastPropertyId = property.id;

--- a/lib/src/annotations.dart
+++ b/lib/src/annotations.dart
@@ -1,5 +1,5 @@
 class Entity {
-  final int uid;
+  final int/*?*/ uid;
 
   const Entity({this.uid});
 }
@@ -13,13 +13,13 @@ class Entity {
 ///
 /// Use OBXPropertyType and OBXPropertyFlag values, resp. for type and flag.
 class Property {
-  final int uid, type, flag;
+  final int/*?*/ uid, type, flag;
 
   const Property({this.type, this.flag, this.uid});
 }
 
 class Id {
-  final int uid;
+  final int/*?*/ uid;
 
   const Id({this.uid});
 }

--- a/lib/src/annotations.dart
+++ b/lib/src/annotations.dart
@@ -1,5 +1,5 @@
 class Entity {
-  final int/*?*/ uid;
+  final int /*?*/ uid;
 
   const Entity({this.uid});
 }
@@ -13,13 +13,13 @@ class Entity {
 ///
 /// Use OBXPropertyType and OBXPropertyFlag values, resp. for type and flag.
 class Property {
-  final int/*?*/ uid, type, flag;
+  final int /*?*/ uid, type, flag;
 
   const Property({this.type, this.flag, this.uid});
 }
 
 class Id {
-  final int/*?*/ uid;
+  final int /*?*/ uid;
 
   const Id({this.uid});
 }

--- a/lib/src/bindings/bindings.dart
+++ b/lib/src/bindings/bindings.dart
@@ -7,7 +7,7 @@ import 'objectbox-c.dart';
 export 'objectbox-c.dart';
 
 ObjectBoxC loadObjectBoxLib() {
-  DynamicLibrary lib;
+  DynamicLibrary/*?*/ lib;
   var libName = 'objectbox';
   if (Platform.isWindows) {
     libName += '.dll';
@@ -30,6 +30,6 @@ ObjectBoxC loadObjectBoxLib() {
   return ObjectBoxC(lib);
 }
 
-ObjectBoxC _cachedBindings;
+ObjectBoxC/*?*/ _cachedBindings;
 
 ObjectBoxC get bindings => _cachedBindings ??= loadObjectBoxLib();

--- a/lib/src/bindings/bindings.dart
+++ b/lib/src/bindings/bindings.dart
@@ -7,7 +7,7 @@ import 'objectbox-c.dart';
 export 'objectbox-c.dart';
 
 ObjectBoxC loadObjectBoxLib() {
-  DynamicLibrary/*?*/ lib;
+  DynamicLibrary /*?*/ lib;
   var libName = 'objectbox';
   if (Platform.isWindows) {
     libName += '.dll';
@@ -30,6 +30,6 @@ ObjectBoxC loadObjectBoxLib() {
   return ObjectBoxC(lib);
 }
 
-ObjectBoxC/*?*/ _cachedBindings;
+ObjectBoxC /*?*/ _cachedBindings;
 
 ObjectBoxC get bindings => _cachedBindings ??= loadObjectBoxLib();

--- a/lib/src/bindings/data_visitor.dart
+++ b/lib/src/bindings/data_visitor.dart
@@ -36,13 +36,13 @@ int _forwarder(Pointer<Void> callbackId, Pointer<Void> dataPtr, int size) {
   }
 
   final callback = _callbacks[callbackId.cast<Int64>().value];
+  if (callback == null) return 0;
   return callback(dataPtr.cast<Uint8>(), size) ? 1 : 0;
 }
 
 /// A data visitor wrapper/forwarder to be used where obx_data_visitor is expected.
 class DataVisitor {
-  int _id;
-  Pointer<Int64> _idPtr;
+  final Pointer<Int64> _idPtr = allocate<Int64>();
 
   Pointer<NativeFunction<obx_data_visitor>> get fn =>
       Pointer.fromFunction(_forwarder, 0);
@@ -62,16 +62,13 @@ class DataVisitor {
       }
     }
     // register the visitor
-    _id = _lastId;
-    _callbacks[_id] = callback;
-
-    _idPtr = allocate<Int64>();
-    _idPtr.value = _id;
+    _idPtr.value = _lastId;
+    _callbacks[_idPtr.value] = callback;
   }
 
   void close() {
     // unregister the visitor
-    _callbacks.remove(_id);
+    _callbacks.remove(_idPtr.value);
     free(_idPtr);
   }
 }

--- a/lib/src/bindings/flatbuffers.dart
+++ b/lib/src/bindings/flatbuffers.dart
@@ -158,7 +158,7 @@ class OBXFlatbuffersManager<T> {
 
     for (var i = 0; i < bytesArray.ref.count; i++) {
       final bytesPtr = bytesArray.ref.bytes.elementAt(i);
-      if (bytesPtr == null || bytesPtr.address == 0 || bytesPtr.ref.size == 0) {
+      if (bytesPtr == null || bytesPtr == nullptr || bytesPtr.ref.size == 0) {
         throw ObjectBoxException(
             dartMsg: "can't access data of empty OBX_bytes");
       }
@@ -176,7 +176,7 @@ class OBXFlatbuffersManager<T> {
 
     for (var i = 0; i < bytesArray.ref.count; i++) {
       final bytesPtr = bytesArray.ref.bytes.elementAt(i);
-      if (bytesPtr == nullptr || bytesPtr.ref.size == 0) {
+      if (bytesPtr == null || bytesPtr == nullptr || bytesPtr.ref.size == 0) {
         result[i] = null;
       } else {
         result[i] = unmarshalWithMissing(

--- a/lib/src/bindings/flatbuffers.dart
+++ b/lib/src/bindings/flatbuffers.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data' show Uint8List;
 
 import 'package:flat_buffers/flat_buffers.dart' as fb;
 
+import '../common.dart';
 import 'bindings.dart';
 import 'structs.dart';
 import '../modelinfo/index.dart';
@@ -42,11 +43,11 @@ class OBXFlatbuffersManager<T> {
     var builder = fb.Builder(initialSize: 1024);
 
     // write all strings
-    final offsets = <String, int>{};
-    _modelEntity.properties.forEach((p) {
+    final offsets = <int, int>{};
+    _modelEntity.properties.forEach((ModelProperty p) {
       switch (p.type) {
         case OBXPropertyType.String:
-          offsets[p.name] = builder.writeString(propVals[p.name]);
+          offsets[p.id.id] = builder.writeString(propVals[p.name]);
           break;
       }
     });
@@ -54,8 +55,9 @@ class OBXFlatbuffersManager<T> {
     // create table and write actual properties
     // TODO: make sure that Id property has a value >= 1
     builder.startTable();
-    _modelEntity.properties.forEach((p) {
-      var field = p.id.id - 1, value = propVals[p.name];
+    _modelEntity.properties.forEach((ModelProperty p) {
+      final field = p.id.id - 1;
+      final value = propVals[p.name];
       switch (p.type) {
         case OBXPropertyType.Bool:
           builder.addBool(field, value);
@@ -76,7 +78,7 @@ class OBXFlatbuffersManager<T> {
           builder.addInt64(field, value);
           break;
         case OBXPropertyType.String:
-          builder.addOffset(field, offsets[p.name]);
+          builder.addOffset(field, offsets[p.id.id] /*!*/);
           break;
         case OBXPropertyType.Float:
           builder.addFloat32(field, value);
@@ -94,7 +96,10 @@ class OBXFlatbuffersManager<T> {
     return OBX_bytes_wrapper.managedCopyOf(builder.finish(endOffset));
   }
 
-  T unmarshal(final Uint8List bytes) {
+  T unmarshal(Pointer<Uint8> dataPtr, int length) {
+    // create a no-copy view
+    final bytes = dataPtr.asTypedList(length);
+
     final entity = _OBXFBEntity(bytes);
     final propVals = <String, dynamic>{};
 
@@ -139,18 +144,43 @@ class OBXFlatbuffersManager<T> {
     return _entityBuilder(propVals);
   }
 
+  T /*?*/ unmarshalWithMissing(Pointer<Uint8> dataPtr, int length) {
+    if (dataPtr == null || dataPtr.address == 0 || length == 0) {
+      return null;
+    }
+    return unmarshal(dataPtr, length);
+  }
+
   // expects pointer to OBX_bytes_array and manually resolves its contents (see objectbox.h)
-  List<T> unmarshalArray(final Pointer<OBX_bytes_array> bytesArray,
-      {bool allowMissing = false}) {
+  List<T> unmarshalArray(final Pointer<OBX_bytes_array> bytesArray) {
     final result = <T>[];
     result.length = bytesArray.ref.count;
 
     for (var i = 0; i < bytesArray.ref.count; i++) {
       final bytesPtr = bytesArray.ref.bytes.elementAt(i);
-      if (allowMissing && (bytesPtr == nullptr || bytesPtr.ref.size == 0)) {
+      if (bytesPtr == null || bytesPtr.address == 0 || bytesPtr.ref.size == 0) {
+        throw ObjectBoxException(
+            dartMsg: "can't access data of empty OBX_bytes");
+      }
+      result[i] = unmarshal(bytesPtr.ref.data.cast<Uint8>(), bytesPtr.ref.size);
+    }
+
+    return result;
+  }
+
+  // expects pointer to OBX_bytes_array and manually resolves its contents (see objectbox.h)
+  List<T /*?*/ > unmarshalArrayWithMissing(
+      final Pointer<OBX_bytes_array> bytesArray) {
+    final result = <T /*?*/ >[];
+    result.length = bytesArray.ref.count;
+
+    for (var i = 0; i < bytesArray.ref.count; i++) {
+      final bytesPtr = bytesArray.ref.bytes.elementAt(i);
+      if (bytesPtr == nullptr || bytesPtr.ref.size == 0) {
         result[i] = null;
       } else {
-        result[i] = unmarshal(OBX_bytes_wrapper.safeDataAccess(bytesPtr));
+        result[i] = unmarshalWithMissing(
+            bytesPtr.ref.data.cast<Uint8>(), bytesPtr.ref.size);
       }
     }
 

--- a/lib/src/bindings/helpers.dart
+++ b/lib/src/bindings/helpers.dart
@@ -16,14 +16,14 @@ bool checkObxSuccess(int code) {
   return true;
 }
 
-Pointer<T> checkObxPtr<T extends NativeType>(Pointer<T> ptr, String dartMsg) {
+Pointer<T> checkObxPtr<T extends NativeType>(Pointer<T>/*?*/ ptr, String dartMsg) {
   if (ptr == null || ptr.address == 0) {
     throw latestNativeError(dartMsg: dartMsg);
   }
   return ptr;
 }
 
-ObjectBoxException latestNativeError({String dartMsg, int codeIfMissing}) {
+ObjectBoxException latestNativeError({String/*?*/ dartMsg, int/*?*/ codeIfMissing}) {
   final code = bindings.obx_last_error_code();
   final text = cString(bindings.obx_last_error_message());
 

--- a/lib/src/bindings/helpers.dart
+++ b/lib/src/bindings/helpers.dart
@@ -16,14 +16,16 @@ bool checkObxSuccess(int code) {
   return true;
 }
 
-Pointer<T> checkObxPtr<T extends NativeType>(Pointer<T>/*?*/ ptr, String dartMsg) {
+Pointer<T> checkObxPtr<T extends NativeType>(
+    Pointer<T> /*?*/ ptr, String dartMsg) {
   if (ptr == null || ptr.address == 0) {
     throw latestNativeError(dartMsg: dartMsg);
   }
   return ptr;
 }
 
-ObjectBoxException latestNativeError({String/*?*/ dartMsg, int/*?*/ codeIfMissing}) {
+ObjectBoxException latestNativeError(
+    {String /*?*/ dartMsg, int codeIfMissing = OBX_ERROR_UNKNOWN}) {
   final code = bindings.obx_last_error_code();
   final text = cString(bindings.obx_last_error_message());
 

--- a/lib/src/bindings/structs.dart
+++ b/lib/src/bindings/structs.dart
@@ -30,17 +30,15 @@ R executeWithIdArray<R>(List<int> items, R Function(Pointer<OBX_id_array>) fn) {
 }
 
 class OBX_bytes_wrapper {
-  Pointer<OBX_bytes> _cBytes;
-
-  OBX_bytes_wrapper(this._cBytes);
+  final Pointer<OBX_bytes> _cBytes;
 
   int get size => _cBytes == nullptr ? 0 : _cBytes.ref.size;
 
   Uint8List get data => safeDataAccess(_cBytes);
 
   /// Get access to the data (no-copy)
-  static Uint8List safeDataAccess(Pointer<OBX_bytes> cBytes) =>
-      cBytes.address == 0 || cBytes.ref.size == 0
+  static Uint8List safeDataAccess(Pointer<OBX_bytes> /*?*/ cBytes) =>
+      cBytes == null || cBytes.address == 0 || cBytes.ref.size == 0
           ? throw ObjectBoxException(
               dartMsg: "can't access data of empty OBX_bytes")
           : cBytes.ref.data.cast<Uint8>().asTypedList(cBytes.ref.size);
@@ -51,8 +49,8 @@ class OBX_bytes_wrapper {
 
   /// Returns a pointer to OBX_bytes with copy of the passed data.
   /// Warning: this creates two unmanaged pointers which must be freed manually: OBX_bytes.freeManaged(result).
-  OBX_bytes_wrapper.managedCopyOf(Uint8List data) {
-    _cBytes = allocate<OBX_bytes>();
+  OBX_bytes_wrapper.managedCopyOf(Uint8List data)
+      : _cBytes = allocate<OBX_bytes>() {
     final bytes = _cBytes.ref;
 
     // ObjectBox requires data to be aligned to the length of 4

--- a/lib/src/box.dart
+++ b/lib/src/box.dart
@@ -19,10 +19,10 @@ enum _PutMode {
 /// A box to store objects of a particular class.
 class Box<T> {
   final Store _store;
-  Pointer<OBX_box> _cBox;
-  ModelEntity _modelEntity;
-  ObjectReader<T> _entityReader;
-  OBXFlatbuffersManager<T> _fbManager;
+  /*late final*/ Pointer<OBX_box> _cBox;
+  /*late final*/ ModelEntity _modelEntity;
+  /*late final*/ ObjectReader<T> _entityReader;
+  /*late final*/ OBXFlatbuffersManager<T> _fbManager;
   final bool _supportsBytesArrays;
 
   Box(this._store)

--- a/lib/src/box.dart
+++ b/lib/src/box.dart
@@ -210,7 +210,7 @@ class Box<T> {
 
   /// Returns a list of [ids.length] Objects of type T, each corresponding to the location of its ID in [ids].
   /// Non-existent IDs become null.
-  List<T/*?*/> getMany(List<int> ids) {
+  List<T /*?*/ > getMany(List<int> ids) {
     if (ids.isEmpty) return [];
 
     return executeWithIdArray(
@@ -236,7 +236,7 @@ class Box<T> {
   }
 
   /// Returns a builder to create queries for Object matching supplied criteria.
-  QueryBuilder query([Condition /*?*/ qc]) =>
+  QueryBuilder<T> query([Condition /*?*/ qc]) =>
       QueryBuilder<T>(_store, _fbManager, _modelEntity.id.id, qc);
 
   /// Returns the count of all stored Objects in this box or, if [limit] is not zero, the given [limit], whichever

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -31,11 +31,12 @@ Version versionLib() {
 }
 
 class ObjectBoxException implements Exception {
-  final String dartMsg;
+  final String /*?*/ dartMsg;
   final int nativeCode;
-  final String nativeMsg;
+  final String /*?*/ nativeMsg;
 
-  ObjectBoxException({String dartMsg, int nativeCode, String nativeMsg})
+  ObjectBoxException(
+      {String /*?*/ dartMsg, int nativeCode = 0, String /*?*/ nativeMsg})
       : dartMsg = dartMsg,
         nativeCode = nativeCode,
         nativeMsg = nativeMsg;
@@ -43,8 +44,12 @@ class ObjectBoxException implements Exception {
   @override
   String toString() {
     var result = 'ObjectBoxException: ';
-    if (dartMsg != null) result += dartMsg + ': ';
+    if (dartMsg != null) {
+      result += dartMsg /*!*/;
+      if (nativeCode != 0 || nativeMsg != null) result += ': ';
+    }
     if (nativeCode != 0) result += '$nativeCode ';
-    return result + nativeMsg;
+    if (nativeMsg != null) result += nativeMsg;
+    return result.trimRight();
   }
 }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -7,13 +7,12 @@ import 'common.dart';
 import 'modelinfo/index.dart';
 
 class Model {
-  Pointer<OBX_model> _cModel;
+  final Pointer<OBX_model> _cModel;
 
   Pointer<OBX_model> get ptr => _cModel;
 
-  Model(ModelInfo model) {
-    _cModel = checkObxPtr(bindings.obx_model(), 'failed to create model');
-
+  Model(ModelInfo model)
+      : _cModel = checkObxPtr(bindings.obx_model(), 'failed to create model') {
     try {
       model.entities.forEach(addEntity);
 
@@ -22,7 +21,6 @@ class Model {
           _cModel, model.lastEntityId.id, model.lastEntityId.uid);
     } catch (e) {
       bindings.obx_model_free(_cModel);
-      _cModel = null;
       rethrow;
     }
   }
@@ -31,6 +29,7 @@ class Model {
     if (errorCode == OBX_SUCCESS) return;
 
     throw ObjectBoxException(
+        dartMsg: 'Model building failed',
         nativeCode: bindings.obx_model_error_code(_cModel),
         nativeMsg: cString(bindings.obx_model_error_message(_cModel)));
   }

--- a/lib/src/modelinfo/entity_definition.dart
+++ b/lib/src/modelinfo/entity_definition.dart
@@ -9,7 +9,7 @@ class EntityDefinition<T> {
   final ObjectReader<T> reader;
   final ObjectWriter<T> writer;
 
-  const EntityDefinition({this.model, this.reader, this.writer});
+  const EntityDefinition({/*required*/ this.model, /*required*/ this.reader, /*required*/ this.writer});
 
   Type type() {
     return T;

--- a/lib/src/modelinfo/entity_definition.dart
+++ b/lib/src/modelinfo/entity_definition.dart
@@ -9,7 +9,10 @@ class EntityDefinition<T> {
   final ObjectReader<T> reader;
   final ObjectWriter<T> writer;
 
-  const EntityDefinition({/*required*/ this.model, /*required*/ this.reader, /*required*/ this.writer});
+  const EntityDefinition(
+      {/*required*/ this.model,
+      /*required*/ this.reader,
+      /*required*/ this.writer});
 
   Type type() {
     return T;

--- a/lib/src/modelinfo/iduid.dart
+++ b/lib/src/modelinfo/iduid.dart
@@ -11,7 +11,7 @@ class IdUid {
     uid = newUid;
   }
 
-  IdUid.fromString(String str) {
+  IdUid.fromString(String/*?*/ str) {
     if (str == null || str == '' || str == '0:0') {
       _id = 0;
       _uid = 0;

--- a/lib/src/modelinfo/iduid.dart
+++ b/lib/src/modelinfo/iduid.dart
@@ -29,7 +29,7 @@ class IdUid {
     uid = newUid;
   }
 
-  IdUid.fromString(String/*?*/ str) {
+  IdUid.fromString(String /*?*/ str) {
     if (str == null || str == '' || str == '0:0') {
       _id = 0;
       _uid = 0;

--- a/lib/src/modelinfo/iduid.dart
+++ b/lib/src/modelinfo/iduid.dart
@@ -4,7 +4,25 @@
 ///  * [IDs](https://docs.objectbox.io/advanced/meta-model-ids-and-uids#ids)
 ///  * [UIDs](https://docs.objectbox.io/advanced/meta-model-ids-and-uids#uids)
 class IdUid {
-  int _id, _uid;
+  /*late*/ int _id, _uid;
+
+  int get id => _id;
+
+  set id(int id) {
+    if (id < 0 || id > ((1 << 63) - 1)) {
+      throw Exception('id out of bounds: $id');
+    }
+    _id = id;
+  }
+
+  int get uid => _uid;
+
+  set uid(int uid) {
+    if (uid < 0 || uid > ((1 << 63) - 1)) {
+      throw Exception('uid out of bounds: $uid');
+    }
+    _uid = uid;
+  }
 
   IdUid(int newId, int newUid) {
     id = newId;
@@ -31,23 +49,7 @@ class IdUid {
       : _id = 0,
         _uid = 0;
 
-  set id(int id) {
-    if (id < 0 || id > ((1 << 63) - 1)) {
-      throw Exception('id out of bounds: $id');
-    }
-    _id = id;
-  }
-
-  set uid(int uid) {
-    if (uid < 0 || uid > ((1 << 63) - 1)) {
-      throw Exception('uid out of bounds: $uid');
-    }
-    _uid = uid;
-  }
-
-  int get id => _id;
-
-  int get uid => _uid;
+  bool get isEmpty => _id == 0 && _uid == 0;
 
   @override
   String toString() => '$_id:$_uid';

--- a/lib/src/modelinfo/modelentity.dart
+++ b/lib/src/modelinfo/modelentity.dart
@@ -8,8 +8,8 @@ import 'modelproperty.dart';
 /// information: id, name and last property id.
 class ModelEntity {
   IdUid id;
-  IdUid lastPropertyId = IdUid.empty();
   /*late*/ String _name;
+  IdUid lastPropertyId = IdUid.empty();
   int _flags = 0;
   final _properties = <ModelProperty>[];
   ModelProperty /*?*/ _idProperty;

--- a/lib/src/modelinfo/modelentity.dart
+++ b/lib/src/modelinfo/modelentity.dart
@@ -12,46 +12,46 @@ class ModelEntity {
   /*late*/ String _name;
   int _flags = 0;
   final _properties = <ModelProperty>[];
-  ModelProperty/*?*/ _idProperty;
-  final ModelInfo/*?*/ _model;
+  ModelProperty /*?*/ _idProperty;
+  final ModelInfo /*?*/ _model;
 
   String get name => _name;
 
-  set name(String/*?*/ value) {
+  set name(String /*?*/ value) {
     if (value == null || value.isEmpty) {
       throw Exception('name must not be null or an empty string');
     }
-    _name = value/*!*/;
+    _name = value /*!*/;
   }
 
   int get flags => _flags;
 
-  set flags(int/*?*/ value) {
+  set flags(int /*?*/ value) {
     if (value == null || value < 0) {
       throw Exception('flags must be defined and may not be < 0');
     }
-    _flags = value/*!*/;
+    _flags = value /*!*/;
   }
 
   ModelProperty get idProperty => (_idProperty == null)
       ? throw Exception('idProperty is null')
-      : _idProperty/*!*/;
+      : _idProperty /*!*/;
 
   ModelInfo get model =>
-      (_model == null) ? throw Exception('model is null') : _model/*!*/;
+      (_model == null) ? throw Exception('model is null') : _model /*!*/;
 
   List<ModelProperty> get properties => _properties;
 
-  ModelEntity(this.id, String/*?*/ name, this._model) {
+  ModelEntity(this.id, String /*?*/ name, this._model) {
     this.name = name;
     validate();
   }
 
   ModelEntity.fromMap(Map<String, dynamic> data,
-      {ModelInfo/*?*/ model, bool check = true})
-    :_model = model,
-    id = IdUid.fromString(data['id']),
-    lastPropertyId = IdUid.fromString(data['lastPropertyId']) {
+      {ModelInfo /*?*/ model, bool check = true})
+      : _model = model,
+        id = IdUid.fromString(data['id']),
+        lastPropertyId = IdUid.fromString(data['lastPropertyId']) {
     name = data['name'];
     flags = data['flags'] ?? 0;
 
@@ -80,12 +80,12 @@ class ModelEntity {
           throw Exception(
               "property '${p.name}' with id ${p.id.toString()} has incorrect parent entity reference");
         }
-        if (lastPropertyId/*!*/.id < p.id.id) {
+        if (lastPropertyId /*!*/ .id < p.id.id) {
           throw Exception(
               "lastPropertyId ${lastPropertyId.toString()} is lower than the one of property '${p.name}' with id ${p.id.toString()}");
         }
-        if (lastPropertyId/*!*/.id == p.id.id) {
-          if (lastPropertyId/*!*/.uid != p.id.uid) {
+        if (lastPropertyId /*!*/ .id == p.id.id) {
+          if (lastPropertyId /*!*/ .uid != p.id.uid) {
             throw Exception(
                 "lastPropertyId ${lastPropertyId.toString()} does not match property '${p.name}' with id ${p.id.toString()}");
           }
@@ -94,7 +94,7 @@ class ModelEntity {
       }
 
       if (!lastPropertyIdFound &&
-          !listContains(model.retiredPropertyUids, lastPropertyId/*!*/.uid)) {
+          !listContains(model.retiredPropertyUids, lastPropertyId /*!*/ .uid)) {
         throw Exception(
             'lastPropertyId ${lastPropertyId.toString()} does not match any property');
       }
@@ -111,12 +111,12 @@ class ModelEntity {
     return ret;
   }
 
-  ModelProperty/*?*/ _findPropertyByUid(int uid) {
+  ModelProperty /*?*/ _findPropertyByUid(int uid) {
     final idx = properties.indexWhere((p) => p.id.uid == uid);
     return idx == -1 ? null : properties[idx];
   }
 
-  ModelProperty/*?*/ _findPropertyByName(String name) {
+  ModelProperty /*?*/ _findPropertyByName(String name) {
     final found = properties
         .where((p) => p.name.toLowerCase() == name.toLowerCase())
         .toList();
@@ -128,8 +128,8 @@ class ModelEntity {
     return found[0];
   }
 
-  ModelProperty/*?*/ findSameProperty(ModelProperty other) {
-    ModelProperty/*?*/ ret;
+  ModelProperty /*?*/ findSameProperty(ModelProperty other) {
+    ModelProperty /*?*/ ret;
     if (other.id.uid != 0) ret = _findPropertyByUid(other.id.uid);
     return ret ??= _findPropertyByName(other.name);
   }

--- a/lib/src/modelinfo/modelinfo.dart
+++ b/lib/src/modelinfo/modelinfo.dart
@@ -145,9 +145,11 @@ class ModelInfo {
     return ret;
   }
 
-  ModelEntity findEntityByUid(int uid) {
+  ModelEntity findEntityByUid(int uid, {bool required = false}) {
     final idx = entities.indexWhere((e) => e.id.uid == uid);
-    return idx == -1 ? null : entities[idx];
+    if (idx >= 0) return entities[idx];
+    if (required) throw ArgumentError.value(uid, 'uid');
+    return null;
   }
 
   ModelEntity findEntityByName(String name) {

--- a/lib/src/modelinfo/modelinfo.dart
+++ b/lib/src/modelinfo/modelinfo.dart
@@ -51,7 +51,8 @@ class ModelInfo {
         retiredPropertyUids = List<int>.from(data['retiredPropertyUids'] ?? []),
         retiredRelationUids = List<int>.from(data['retiredRelationUids'] ?? []),
         modelVersion = data['modelVersion'] ?? 0,
-        modelVersionParserMinimum = data['modelVersionParserMinimum'] ?? _maxModelVersion,
+        modelVersionParserMinimum =
+            data['modelVersionParserMinimum'] ?? _maxModelVersion,
         version = data['version'] ?? 1 {
     if (data['entities'] == null) throw Exception('entities is null');
     for (final e in data['entities']) {
@@ -127,12 +128,12 @@ class ModelInfo {
     return entity;
   }
 
-  ModelEntity/*?*/ findEntityByUid(int uid) {
+  ModelEntity /*?*/ findEntityByUid(int uid) {
     final idx = entities.indexWhere((e) => e.id.uid == uid);
     return idx < 0 ? null : entities[idx];
   }
 
-  ModelEntity/*?*/ findEntityByName(String name) {
+  ModelEntity /*?*/ findEntityByName(String name) {
     final found = entities
         .where((e) => e.name.toLowerCase() == name.toLowerCase())
         .toList();
@@ -144,8 +145,8 @@ class ModelInfo {
     return found[0];
   }
 
-  ModelEntity/*?*/ findSameEntity(ModelEntity other) {
-    ModelEntity ret;
+  ModelEntity /*?*/ findSameEntity(ModelEntity other) {
+    ModelEntity /*?*/ ret;
     if (other.id.uid != 0) ret = findEntityByUid(other.id.uid);
     ret ??= findEntityByName(other.name);
     return ret;

--- a/lib/src/modelinfo/modelproperty.dart
+++ b/lib/src/modelinfo/modelproperty.dart
@@ -4,31 +4,47 @@ import 'iduid.dart';
 /// ModelProperty describes a single property of an entity, i.e. its id, name, type and flags.
 class ModelProperty {
   IdUid id;
-  String name;
-  int type, flags;
-  ModelEntity entity;
+  /*late*/ String _name;
+  /*late*/ int _type, _flags;
+  ModelEntity/*?*/ entity;
 
-  ModelProperty(this.id, this.name, this.type, this.flags, this.entity) {
-    validate();
+  String get name => _name;
+
+  set name(String/*?*/ value) {
+    if (value == null || value.isEmpty) {
+      throw Exception('name must not be null or an empty string');
+    }
+    _name = value/*!*/;
   }
 
-  ModelProperty.fromMap(Map<String, dynamic> data, this.entity,
-      {bool check = true}) {
-    id = IdUid.fromString(data['id']);
-    name = data['name'];
-    type = data['type'];
-    flags = data.containsKey('flags') ? data['flags'] : 0;
-    if (check) validate();
-  }
+  int get type => _type;
 
-  void validate() {
-    if (type == null || type < 0) {
+  set type(int/*?*/ value) {
+    if (value == null || value < 0) {
       throw Exception('type must be defined and may not be < 0');
     }
-    if (flags == null || flags < 0) {
+    _type = value/*!*/;
+  }
+
+  int get flags => _flags;
+
+  set flags(int/*?*/ value) {
+    if (value == null || value < 0) {
       throw Exception('flags must be defined and may not be < 0');
     }
+    _flags = value/*!*/;
   }
+
+  ModelProperty(this.id, String/*?*/ name, int/*?*/ type, int/*?*/ flags,
+      this.entity) {
+    this.name = name;
+    this.type = type;
+    this.flags = flags;
+  }
+
+  ModelProperty.fromMap(Map<String, dynamic> data, ModelEntity/*?*/ entity)
+      : this(IdUid.fromString(data['id']), data['name'], data['type'],
+            data['flags'] ?? 0, entity);
 
   Map<String, dynamic> toMap() {
     final ret = <String, dynamic>{};

--- a/lib/src/modelinfo/modelproperty.dart
+++ b/lib/src/modelinfo/modelproperty.dart
@@ -6,43 +6,43 @@ class ModelProperty {
   IdUid id;
   /*late*/ String _name;
   /*late*/ int _type, _flags;
-  ModelEntity/*?*/ entity;
+  ModelEntity /*?*/ entity;
 
   String get name => _name;
 
-  set name(String/*?*/ value) {
+  set name(String /*?*/ value) {
     if (value == null || value.isEmpty) {
       throw Exception('name must not be null or an empty string');
     }
-    _name = value/*!*/;
+    _name = value /*!*/;
   }
 
   int get type => _type;
 
-  set type(int/*?*/ value) {
+  set type(int /*?*/ value) {
     if (value == null || value < 0) {
       throw Exception('type must be defined and may not be < 0');
     }
-    _type = value/*!*/;
+    _type = value /*!*/;
   }
 
   int get flags => _flags;
 
-  set flags(int/*?*/ value) {
+  set flags(int /*?*/ value) {
     if (value == null || value < 0) {
       throw Exception('flags must be defined and may not be < 0');
     }
-    _flags = value/*!*/;
+    _flags = value /*!*/;
   }
 
-  ModelProperty(this.id, String/*?*/ name, int/*?*/ type, int/*?*/ flags,
+  ModelProperty(this.id, String /*?*/ name, int /*?*/ type, int /*?*/ flags,
       this.entity) {
     this.name = name;
     this.type = type;
     this.flags = flags;
   }
 
-  ModelProperty.fromMap(Map<String, dynamic> data, ModelEntity/*?*/ entity)
+  ModelProperty.fromMap(Map<String, dynamic> data, ModelEntity /*?*/ entity)
       : this(IdUid.fromString(data['id']), data['name'], data['type'],
             data['flags'] ?? 0, entity);
 

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -26,9 +26,9 @@ class _Observable {
     for (var i = 0; i < mutated_count; i++) {
       // call schema's callback
       if (_any.containsKey(storeAddress) &&
-          _any[storeAddress].containsKey(mutated_ids[i])) {
-        _any[storeAddress]
-            [mutated_ids[i]](user_data, mutated_ids, mutated_count);
+          _any[storeAddress] /*!*/ .containsKey(mutated_ids[i])) {
+        _any[storeAddress] /*!*/
+            [mutated_ids[i]] /*!*/ (user_data, mutated_ids, mutated_count);
       }
     }
   }
@@ -69,7 +69,7 @@ extension Streamable<T> on Query<T> {
     final storeAddress = store.ptr.address;
 
     _Observable._any[storeAddress] ??= <int, Any>{};
-    _Observable._any[storeAddress][entityId] ??= (u, _, __) {
+    _Observable._any[storeAddress] /*!*/ [entityId] ??= (u, _, __) {
       // dummy value to trigger an event
       _Observable.controller.add(u.address);
     };

--- a/lib/src/query/property.dart
+++ b/lib/src/query/property.dart
@@ -1,21 +1,19 @@
 part of query;
 
 abstract class PropertyQuery<T> {
-  Pointer<OBX_query_prop> _cProp;
-  int _type;
+  final Pointer<OBX_query_prop> _cProp;
+  final int _type;
   bool _distinct;
 
-  PropertyQuery(Pointer<OBX_query> cQuery, int propertyId, int obxType) {
-    _type = obxType;
-    _cProp = checkObxPtr(
-        bindings.obx_query_prop(cQuery, propertyId), 'property query');
-  }
+  PropertyQuery(Pointer<OBX_query> cQuery, int propertyId, this._type)
+      : _cProp = checkObxPtr(
+            bindings.obx_query_prop(cQuery, propertyId), 'property query');
 
   /// Returns values of this property matching the query.
   ///
   /// Results are in no particular order. Excludes null values.
   /// Set [replaceNullWith] to return null values as that value.
-  List<T> find({T replaceNullWith});
+  List<T> find({T/*?*/ replaceNullWith});
 
   void close() {
     checkObx(bindings.obx_query_prop_close(_cProp));
@@ -103,7 +101,7 @@ class IntegerPropertyQuery extends PropertyQuery<int> with _CommonNumeric {
   }
 
   @override
-  List<int> find({int replaceNullWith}) {
+  List<int> find({int/*?*/ replaceNullWith}) {
     switch (_type) {
       case OBXPropertyType.Bool:
       case OBXPropertyType.Byte:
@@ -179,7 +177,7 @@ class DoublePropertyQuery extends PropertyQuery<double> with _CommonNumeric {
   }
 
   @override
-  List<double> find({double replaceNullWith}) {
+  List<double> find({double/*?*/ replaceNullWith}) {
     switch (_type) {
       case OBXPropertyType.Float:
         final cDefault = _cDefault<Float>(replaceNullWith);
@@ -230,7 +228,7 @@ class StringPropertyQuery extends PropertyQuery<String> {
   }
 
   @override
-  List<String> find({String replaceNullWith}) {
+  List<String> find({String/*?*/ replaceNullWith}) {
     final cDefault = replaceNullWith == null
         ? nullptr
         : Utf8.toUtf8(replaceNullWith).cast<Int8>();

--- a/lib/src/query/property.dart
+++ b/lib/src/query/property.dart
@@ -3,7 +3,7 @@ part of query;
 abstract class PropertyQuery<T> {
   final Pointer<OBX_query_prop> _cProp;
   final int _type;
-  bool _distinct;
+  bool _distinct = false;
 
   PropertyQuery(Pointer<OBX_query> cQuery, int propertyId, this._type)
       : _cProp = checkObxPtr(
@@ -13,7 +13,7 @@ abstract class PropertyQuery<T> {
   ///
   /// Results are in no particular order. Excludes null values.
   /// Set [replaceNullWith] to return null values as that value.
-  List<T> find({T/*?*/ replaceNullWith});
+  List<T> find({T /*?*/ replaceNullWith});
 
   void close() {
     checkObx(bindings.obx_query_prop_close(_cProp));
@@ -45,7 +45,7 @@ abstract class PropertyQuery<T> {
       Pointer<ValT> cDefault,
       List<R> Function(Pointer<StructT>) listReadFn,
       void Function(Pointer<StructT>) listFreeFn) {
-    Pointer<StructT> cItems;
+    Pointer<StructT> cItems = nullptr;
     try {
       cItems = checkObxPtr(findFn(_cProp, cDefault), 'Property query failed');
       return listReadFn(cItems);
@@ -101,7 +101,7 @@ class IntegerPropertyQuery extends PropertyQuery<int> with _CommonNumeric {
   }
 
   @override
-  List<int> find({int/*?*/ replaceNullWith}) {
+  List<int> find({int /*?*/ replaceNullWith}) {
     switch (_type) {
       case OBXPropertyType.Bool:
       case OBXPropertyType.Byte:
@@ -177,7 +177,7 @@ class DoublePropertyQuery extends PropertyQuery<double> with _CommonNumeric {
   }
 
   @override
-  List<double> find({double/*?*/ replaceNullWith}) {
+  List<double> find({double /*?*/ replaceNullWith}) {
     switch (_type) {
       case OBXPropertyType.Float:
         final cDefault = _cDefault<Float>(replaceNullWith);
@@ -228,7 +228,7 @@ class StringPropertyQuery extends PropertyQuery<String> {
   }
 
   @override
-  List<String> find({String/*?*/ replaceNullWith}) {
+  List<String> find({String /*?*/ replaceNullWith}) {
     final cDefault = replaceNullWith == null
         ? nullptr
         : Utf8.toUtf8(replaceNullWith).cast<Int8>();

--- a/lib/src/query/query.dart
+++ b/lib/src/query/query.dart
@@ -317,7 +317,7 @@ class StringCondition extends PropertyCondition<String> {
   final bool _caseSensitive;
 
   StringCondition(ConditionOp op, QueryProperty prop, String value,
-      String/*?*/ value2, bool caseSensitive)
+      String /*?*/ value2, bool caseSensitive)
       : _caseSensitive = caseSensitive,
         super(op, prop, value, value2);
 
@@ -339,16 +339,16 @@ class StringCondition extends PropertyCondition<String> {
 
   int _inside(QueryBuilder builder) {
     final func = bindings.obx_qb_in_strings;
-    final listLength = _list/*!*/.length;
+    final listLength = _list /*!*/ .length;
     final arrayOfCStrings = allocate<Pointer<Int8>>(count: listLength);
     try {
-      for (var i = 0; i < _list/*!*/.length; i++) {
-        arrayOfCStrings[i] = Utf8.toUtf8(_list/*!*/[i]).cast<Int8>();
+      for (var i = 0; i < _list /*!*/ .length; i++) {
+        arrayOfCStrings[i] = Utf8.toUtf8(_list /*!*/ [i]).cast<Int8>();
       }
       return func(builder._cBuilder, _property._propertyId, arrayOfCStrings,
           listLength, _caseSensitive);
     } finally {
-      for (var i = 0; i < _list/*!*/.length; i++) {
+      for (var i = 0; i < _list /*!*/ .length; i++) {
         free(arrayOfCStrings.elementAt(i).value);
       }
       free(arrayOfCStrings);
@@ -390,14 +390,15 @@ class StringCondition extends PropertyCondition<String> {
 }
 
 class IntegerCondition extends PropertyCondition<int> {
-  IntegerCondition(ConditionOp op, QueryProperty prop, int/*?*/ value, [int/*?*/ value2])
+  IntegerCondition(ConditionOp op, QueryProperty prop, int /*?*/ value,
+      [int /*?*/ value2])
       : super(op, prop, value, value2);
 
   IntegerCondition.fromList(ConditionOp op, QueryProperty prop, List<int> list)
       : super.fromList(op, prop, list);
 
   int _op1(QueryBuilder builder,
-      int Function(Pointer<OBX_query_builder>, int, int/*?*/) func) {
+      int Function(Pointer<OBX_query_builder>, int, int /*?*/) func) {
     return func(builder._cBuilder, _property._propertyId, _value);
   }
 
@@ -405,13 +406,13 @@ class IntegerCondition extends PropertyCondition<int> {
       QueryBuilder builder,
       int Function(Pointer<OBX_query_builder>, int, Pointer<T>, int) func,
       void Function(Pointer<T>, int, int) setIndex) {
-    final length = _list/*!*/.length;
+    final length = _list /*!*/ .length;
     final listPtr = allocate<T>(count: length);
     try {
       for (var i = 0; i < length; i++) {
         // Error: The operator '[]=' isn't defined for the type 'Pointer<T>
         // listPtr[i] = _list[i];
-        setIndex(listPtr, i, _list/*!*/[i]);
+        setIndex(listPtr, i, _list /*!*/ [i]);
       }
       return func(builder._cBuilder, _property._propertyId, listPtr, length);
     } finally {
@@ -474,7 +475,7 @@ class IntegerCondition extends PropertyCondition<int> {
 
 class DoubleCondition extends PropertyCondition<double> {
   DoubleCondition(
-      ConditionOp op, QueryProperty prop, double value, double/*?*/ value2)
+      ConditionOp op, QueryProperty prop, double value, double /*?*/ value2)
       : super(op, prop, value, value2) {
     assert(op != ConditionOp.eq,
         'Equality operator is not supported on floating point numbers - use between() instead.');
@@ -611,7 +612,7 @@ class Query<T> {
 
   /// Finds Objects matching the query and returns the first result or null
   /// if there are no results.
-  T/*?*/ findFirst() {
+  T /*?*/ findFirst() {
     offset(0);
     limit(1);
     final list = find();

--- a/lib/src/query/query.dart
+++ b/lib/src/query/query.dart
@@ -367,8 +367,8 @@ class StringCondition extends PropertyCondition<String> {
 class StringListCondition extends PropertyCondition<List<String>> {
   final bool _caseSensitive;
 
-  StringListCondition(
-      ConditionOp op, QueryProperty prop, List<String> value, bool caseSensitive)
+  StringListCondition(ConditionOp op, QueryProperty prop, List<String> value,
+      bool caseSensitive)
       : _caseSensitive = caseSensitive,
         super(op, prop, value);
 

--- a/lib/src/query/query.dart
+++ b/lib/src/query/query.dart
@@ -55,7 +55,10 @@ class QueryProperty {
 }
 
 class QueryStringProperty extends QueryProperty {
-  QueryStringProperty({int entityId, int propertyId, int obxType})
+  QueryStringProperty(
+      {/*required*/ int entityId,
+      /*required*/ int propertyId,
+      /*required*/ int obxType})
       : super(entityId, propertyId, obxType);
 
   Condition _op(String p, ConditionOp cop, [bool caseSensitive = false]) {
@@ -128,7 +131,10 @@ class QueryStringProperty extends QueryProperty {
 }
 
 class QueryIntegerProperty extends QueryProperty {
-  QueryIntegerProperty({int entityId, int propertyId, int obxType})
+  QueryIntegerProperty(
+      {/*required*/ int entityId,
+      /*required*/ int propertyId,
+      /*required*/ int obxType})
       : super(entityId, propertyId, obxType);
 
   Condition _op(int p, ConditionOp cop) {
@@ -176,10 +182,13 @@ class QueryIntegerProperty extends QueryProperty {
 }
 
 class QueryDoubleProperty extends QueryProperty {
-  QueryDoubleProperty({int entityId, int propertyId, int obxType})
+  QueryDoubleProperty(
+      {/*required*/ int entityId,
+      /*required*/ int propertyId,
+      /*required*/ int obxType})
       : super(entityId, propertyId, obxType);
 
-  Condition _op(ConditionOp op, double p1, double p2) {
+  Condition _op(ConditionOp op, double p1, double /*?*/ p2) {
     return DoubleCondition(op, this, p1, p2);
   }
 
@@ -210,7 +219,10 @@ class QueryDoubleProperty extends QueryProperty {
 }
 
 class QueryBooleanProperty extends QueryProperty {
-  QueryBooleanProperty({int entityId, int propertyId, int obxType})
+  QueryBooleanProperty(
+      {/*required*/ int entityId,
+      /*required*/ int propertyId,
+      /*required*/ int obxType})
       : super(entityId, propertyId, obxType);
 
   Condition equals(bool p) {
@@ -279,8 +291,8 @@ abstract class Condition {
 
 abstract class PropertyCondition<DartType> extends Condition {
   final QueryProperty _property;
-  DartType _value, _value2;
-  List<DartType> _list;
+  DartType /*?*/ _value, _value2;
+  List<DartType> /*?*/ _list;
 
   final ConditionOp _op;
 
@@ -302,19 +314,17 @@ abstract class PropertyCondition<DartType> extends Condition {
 }
 
 class StringCondition extends PropertyCondition<String> {
-  bool _caseSensitive;
+  final bool _caseSensitive;
 
   StringCondition(ConditionOp op, QueryProperty prop, String value,
-      [String value2, bool caseSensitive])
-      : super(op, prop, value, value2) {
-    _caseSensitive = caseSensitive;
-  }
+      String/*?*/ value2, bool caseSensitive)
+      : _caseSensitive = caseSensitive,
+        super(op, prop, value, value2);
 
   StringCondition._fromList(
       ConditionOp op, QueryProperty prop, List<String> list, bool caseSensitive)
-      : super.fromList(op, prop, list) {
-    _caseSensitive = caseSensitive;
-  }
+      : _caseSensitive = caseSensitive,
+        super.fromList(op, prop, list);
 
   int _op1(QueryBuilder builder,
       int Function(Pointer<OBX_query_builder>, int, Pointer<Int8>, bool) func) {
@@ -329,16 +339,16 @@ class StringCondition extends PropertyCondition<String> {
 
   int _inside(QueryBuilder builder) {
     final func = bindings.obx_qb_in_strings;
-    final listLength = _list.length;
+    final listLength = _list/*!*/.length;
     final arrayOfCStrings = allocate<Pointer<Int8>>(count: listLength);
     try {
-      for (var i = 0; i < _list.length; i++) {
-        arrayOfCStrings[i] = Utf8.toUtf8(_list[i]).cast<Int8>();
+      for (var i = 0; i < _list/*!*/.length; i++) {
+        arrayOfCStrings[i] = Utf8.toUtf8(_list/*!*/[i]).cast<Int8>();
       }
       return func(builder._cBuilder, _property._propertyId, arrayOfCStrings,
           listLength, _caseSensitive);
     } finally {
-      for (var i = 0; i < _list.length; i++) {
+      for (var i = 0; i < _list/*!*/.length; i++) {
         free(arrayOfCStrings.elementAt(i).value);
       }
       free(arrayOfCStrings);
@@ -380,14 +390,14 @@ class StringCondition extends PropertyCondition<String> {
 }
 
 class IntegerCondition extends PropertyCondition<int> {
-  IntegerCondition(ConditionOp op, QueryProperty prop, int value, [int value2])
+  IntegerCondition(ConditionOp op, QueryProperty prop, int/*?*/ value, [int/*?*/ value2])
       : super(op, prop, value, value2);
 
   IntegerCondition.fromList(ConditionOp op, QueryProperty prop, List<int> list)
       : super.fromList(op, prop, list);
 
   int _op1(QueryBuilder builder,
-      int Function(Pointer<OBX_query_builder>, int, int) func) {
+      int Function(Pointer<OBX_query_builder>, int, int/*?*/) func) {
     return func(builder._cBuilder, _property._propertyId, _value);
   }
 
@@ -395,13 +405,13 @@ class IntegerCondition extends PropertyCondition<int> {
       QueryBuilder builder,
       int Function(Pointer<OBX_query_builder>, int, Pointer<T>, int) func,
       void Function(Pointer<T>, int, int) setIndex) {
-    final length = _list.length;
+    final length = _list/*!*/.length;
     final listPtr = allocate<T>(count: length);
     try {
       for (var i = 0; i < length; i++) {
         // Error: The operator '[]=' isn't defined for the type 'Pointer<T>
         // listPtr[i] = _list[i];
-        setIndex(listPtr, i, _list[i]);
+        setIndex(listPtr, i, _list/*!*/[i]);
       }
       return func(builder._cBuilder, _property._propertyId, listPtr, length);
     } finally {
@@ -464,7 +474,7 @@ class IntegerCondition extends PropertyCondition<int> {
 
 class DoubleCondition extends PropertyCondition<double> {
   DoubleCondition(
-      ConditionOp op, QueryProperty prop, double value, double value2)
+      ConditionOp op, QueryProperty prop, double value, double/*?*/ value2)
       : super(op, prop, value, value2) {
     assert(op != ConditionOp.eq,
         'Equality operator is not supported on floating point numbers - use between() instead.');
@@ -548,16 +558,15 @@ class ConditionGroupAll extends ConditionGroup {
 ///
 /// Use [property] to only return values or an aggregate of a single Property.
 class Query<T> {
-  Pointer<OBX_query> _cQuery;
-  Store store;
-  final OBXFlatbuffersManager _fbManager;
-  int entityId;
+  final Pointer<OBX_query> _cQuery;
+  final Store store;
+  final OBXFlatbuffersManager<T> _fbManager;
+  final int entityId;
 
   // package private ctor
   Query._(this.store, this._fbManager, Pointer<OBX_query_builder> cBuilder,
-      this.entityId) {
-    _cQuery = checkObxPtr(bindings.obx_query(cBuilder), 'create query');
-  }
+      this.entityId)
+      : _cQuery = checkObxPtr(bindings.obx_query(cBuilder), 'create query');
 
   /// Configure an [offset] for this query.
   ///
@@ -602,7 +611,7 @@ class Query<T> {
 
   /// Finds Objects matching the query and returns the first result or null
   /// if there are no results.
-  T findFirst() {
+  T/*?*/ findFirst() {
     offset(0);
     limit(1);
     final list = find();
@@ -655,8 +664,7 @@ class Query<T> {
       } else {
         final results = <T>[];
         final visitor = DataVisitor((Pointer<Uint8> dataPtr, int length) {
-          final bytes = dataPtr.asTypedList(length);
-          results.add(_fbManager.unmarshal(bytes));
+          results.add(_fbManager.unmarshal(dataPtr, length));
           return true;
         });
 

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -16,7 +16,7 @@ enum TxMode {
 /// Represents an ObjectBox database and works together with [Box] to allow getting and putting Objects of
 /// specific type.
 class Store {
-  Pointer<OBX_store> _cStore;
+  /*late final*/ Pointer<OBX_store> _cStore;
   final ModelDefinition defs;
 
   /// Creates a BoxStore using the model definition from your
@@ -36,7 +36,10 @@ class Store {
   ///
   /// See our examples for more details.
   Store(this.defs,
-      {String directory, int maxDBSizeInKB, int fileMode, int maxReaders}) {
+      {String /*?*/ directory,
+      int /*?*/ maxDBSizeInKB,
+      int /*?*/ fileMode,
+      int /*?*/ maxReaders}) {
     var model = Model(defs.model);
 
     var opt = bindings.obx_opt();
@@ -74,10 +77,10 @@ class Store {
       // 10199 = OBX_ERROR_STORAGE_GENERAL
       if (e.nativeCode == 10199 &&
           e.nativeMsg != null &&
-          e.nativeMsg.contains('Dir does not exist')) {
+          e.nativeMsg/*!*/.contains('Dir does not exist')) {
         // 13 = permissions denied, 30 = read-only filesystem
-        if (e.nativeMsg.endsWith(' (13)') || e.nativeMsg.endsWith(' (30)')) {
-          final msg = e.nativeMsg +
+        if (e.nativeMsg/*!*/.endsWith(' (13)') || e.nativeMsg/*!*/.endsWith(' (30)')) {
+          final msg = e.nativeMsg/*!*/ +
               " - this usually indicates a problem with permissions; if you're using Flutter you may need to use " +
               'getApplicationDocumentsDirectory() from the path_provider package, see example/README.md';
           throw ObjectBoxException(
@@ -101,7 +104,10 @@ class Store {
   }
 
   EntityDefinition<T> entityDef<T>() {
-    return defs.bindings[T];
+    if (defs.bindings[T] == null) {
+      throw ArgumentError('Unknown entity type ' + T.toString());
+    }
+    return defs.bindings[T]/*!*/;
   }
 
   /// Executes a given function inside a transaction.
@@ -130,7 +136,7 @@ class Store {
 
   /// Return an existing SyncClient associated with the store or null if not available.
   /// See [Sync.client()] to create one first.
-  SyncClient syncClient() => syncClientsStorage[this];
+  SyncClient /*?*/ syncClient() => syncClientsStorage[this];
 
   /// The low-level pointer to this store.
   Pointer<OBX_store> get ptr => _cStore;

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -105,10 +105,11 @@ class Store {
   }
 
   EntityDefinition<T> entityDef<T>() {
-    if (defs.bindings[T] == null) {
+    final binding = defs.bindings[T];
+    if (binding == null) {
       throw ArgumentError('Unknown entity type ' + T.toString());
     }
-    return defs.bindings[T] /*!*/ as EntityDefinition<T>;
+    return binding /*!*/ as EntityDefinition<T>;
   }
 
   /// Executes a given function inside a transaction.

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -77,10 +77,11 @@ class Store {
       // 10199 = OBX_ERROR_STORAGE_GENERAL
       if (e.nativeCode == 10199 &&
           e.nativeMsg != null &&
-          e.nativeMsg/*!*/.contains('Dir does not exist')) {
+          e.nativeMsg /*!*/ .contains('Dir does not exist')) {
         // 13 = permissions denied, 30 = read-only filesystem
-        if (e.nativeMsg/*!*/.endsWith(' (13)') || e.nativeMsg/*!*/.endsWith(' (30)')) {
-          final msg = e.nativeMsg/*!*/ +
+        if (e.nativeMsg /*!*/ .endsWith(' (13)') ||
+            e.nativeMsg /*!*/ .endsWith(' (30)')) {
+          final msg = e.nativeMsg /*!*/ +
               " - this usually indicates a problem with permissions; if you're using Flutter you may need to use " +
               'getApplicationDocumentsDirectory() from the path_provider package, see example/README.md';
           throw ObjectBoxException(
@@ -107,7 +108,7 @@ class Store {
     if (defs.bindings[T] == null) {
       throw ArgumentError('Unknown entity type ' + T.toString());
     }
-    return defs.bindings[T]/*!*/;
+    return defs.bindings[T] /*!*/ as EntityDefinition<T>;
   }
 
   /// Executes a given function inside a transaction.

--- a/lib/src/sync.dart
+++ b/lib/src/sync.dart
@@ -65,7 +65,7 @@ enum SyncRequestUpdatesMode {
 /// Sync client is used to provide ObjectBox Sync client capabilities to your application.
 class SyncClient {
   final Store _store;
-  Pointer<OBX_sync> _cSync;
+  /*late final*/ Pointer<OBX_sync> _cSync;
 
   /// The low-level pointer to this box.
   Pointer<OBX_sync> get ptr => (_cSync.address != 0)
@@ -220,14 +220,14 @@ class Sync {
   /// Sync() annotation enables synchronization for an entity.
   const Sync();
 
-  static bool _syncAvailable;
+  static /*late final*/ bool _syncAvailable;
 
   /// Returns true if the loaded ObjectBox native library supports Sync.
   static bool isAvailable() {
     // TODO remove try-catch after upgrading to objectbox-c v0.11 where obx_sync_available() exists.
     try {
       _syncAvailable ??= bindings.obx_sync_available();
-    } on ArgumentError {
+    } catch (_) {
       _syncAvailable = false;
     }
     return _syncAvailable;

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -15,7 +15,7 @@ class StoreCloseObserver {
     if (!maps.containsKey(store)) {
       maps[store] = <dynamic, void Function()>{};
     }
-    maps[store][key] = listener;
+    maps[store]/*!*/[key] = listener;
   }
 
   /// Removes a [store.close()] event listener.
@@ -23,8 +23,8 @@ class StoreCloseObserver {
     if (!maps.containsKey(store)) {
       return;
     }
-    maps[store].remove(key);
-    if (maps[store].isEmpty) {
+    maps[store]/*!*/.remove(key);
+    if (maps[store]/*!*/.isEmpty) {
       maps.remove(store);
     }
   }
@@ -34,7 +34,7 @@ class StoreCloseObserver {
     if (!maps.containsKey(store)) {
       return [];
     }
-    final listeners = maps[store].values.toList(growable: false);
+    final listeners = maps[store]/*!*/.values.toList(growable: false);
     maps.remove(store);
     return listeners;
   }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -15,7 +15,7 @@ class StoreCloseObserver {
     if (!maps.containsKey(store)) {
       maps[store] = <dynamic, void Function()>{};
     }
-    maps[store]/*!*/[key] = listener;
+    maps[store] /*!*/ [key] = listener;
   }
 
   /// Removes a [store.close()] event listener.
@@ -23,8 +23,8 @@ class StoreCloseObserver {
     if (!maps.containsKey(store)) {
       return;
     }
-    maps[store]/*!*/.remove(key);
-    if (maps[store]/*!*/.isEmpty) {
+    maps[store] /*!*/ .remove(key);
+    if (maps[store] /*!*/ .isEmpty) {
       maps.remove(store);
     }
   }
@@ -34,7 +34,7 @@ class StoreCloseObserver {
     if (!maps.containsKey(store)) {
       return [];
     }
-    final listeners = maps[store]/*!*/.values.toList(growable: false);
+    final listeners = maps[store] /*!*/ .values.toList(growable: false);
     maps.remove(store);
     return listeners;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ homepage: https://objectbox.io
 description: ObjectBox is a super-fast NoSQL ACID compliant object database.
 
 environment:
+#  sdk: ">=2.12.0-0 <3.0.0"
   sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
@@ -16,8 +17,8 @@ dev_dependencies:
   build_runner: ^1.0.0
   objectbox_generator:
     path: generator
-  pedantic: ^1.9.0
-  test: ^1.0.0
+  pedantic: ^1.10.0-nullsafety.0
+  test: ^1.16.0-nullsafety.0
   ffigen: ^1.1.0
 
 ffigen:

--- a/test/box_test.dart
+++ b/test/box_test.dart
@@ -7,9 +7,9 @@ import 'test_env.dart';
 // ignore_for_file: omit_local_variable_types
 
 void main() {
-  TestEnv env;
-  Store store;
-  Box<TestEntity> box;
+  /*late final*/ TestEnv env;
+  /*late final*/ Store store;
+  /*late final*/ Box<TestEntity> box;
 
   final List<TestEntity> simpleItems = [
     'One',

--- a/test/box_test.dart
+++ b/test/box_test.dart
@@ -8,8 +8,10 @@ import 'test_env.dart';
 
 void main() {
   /*late final*/ TestEnv env;
-  /*late final*/ Store store;
-  /*late final*/ Box<TestEntity> box;
+  /*late final*/
+  Store store;
+  /*late final*/
+  Box<TestEntity> box;
 
   final List<TestEntity> simpleItems = [
     'One',
@@ -33,7 +35,7 @@ void main() {
 
   test('.get() returns the correct item', () {
     final int putId = box.put(TestEntity(tString: 'Hello'));
-    final TestEntity item = box.get(putId);
+    final TestEntity item = box.get(putId) /*!*/;
     expect(item.id, equals(putId));
     expect(item.tString, equals('Hello'));
   });
@@ -44,7 +46,7 @@ void main() {
 
   test('.put() and box.get() keep Unicode characters', () {
     final String text = '😄你好';
-    final TestEntity inst = box.get(box.put(TestEntity(tString: text)));
+    final TestEntity inst = box.get(box.put(TestEntity(tString: text))) /*!*/;
     expect(inst.tString, equals(text));
   });
 
@@ -52,7 +54,7 @@ void main() {
     final int putId1 = box.put(TestEntity(tString: 'One'));
     final int putId2 = box.put(TestEntity(tString: 'Two')..id = putId1);
     expect(putId2, equals(putId1));
-    final TestEntity item = box.get(putId2);
+    final TestEntity item = box.get(putId2) /*!*/;
     expect(item.tString, equals('Two'));
   });
 
@@ -94,7 +96,7 @@ void main() {
     final List<int> ids = box.putMany(items);
     expect(ids.length, equals(items.length));
     for (var i = 0; i < items.length; ++i) {
-      expect(box.get(ids[i]).tString, equals(items[i].tString));
+      expect(box.get(ids[i]) /*!*/ .tString, equals(items[i].tString));
     }
   });
 
@@ -114,7 +116,7 @@ void main() {
 
     box.put(TestEntity(tString: largeString));
 
-    items = box.getMany([1, 2]);
+    items = box.getMany([1, 2]) as List<TestEntity /*!*/ >;
     expect(items.length, 2);
     expect(items[0].tString, largeString);
     expect(items[1].tString, largeString);
@@ -128,12 +130,12 @@ void main() {
     while (ids.indexWhere((id) => id == otherId) != -1) {
       ++otherId;
     }
-    final List<TestEntity> fetchedItems =
+    final List<TestEntity /*?*/ > fetchedItems =
         box.getMany([ids[0], otherId, ids[1]]);
     expect(fetchedItems.length, equals(3));
-    expect(fetchedItems[0].tString, equals('One'));
+    expect(fetchedItems[0] /*!*/ .tString, equals('One'));
     expect(fetchedItems[1], equals(null));
-    expect(fetchedItems[2].tString, equals('Two'));
+    expect(fetchedItems[2] /*!*/ .tString, equals('Two'));
   });
 
   test('all limit integers are stored correctly', () {
@@ -154,7 +156,8 @@ void main() {
     ];
     expect('${items[8].tLong}', equals('$int64Min'));
     expect('${items[9].tLong}', equals('$int64Max'));
-    final List<TestEntity> fetchedItems = box.getMany(box.putMany(items));
+    final List<TestEntity> fetchedItems =
+        box.getMany(box.putMany(items)) as List<TestEntity /*!*/ >;
     expect(fetchedItems[0].tChar, equals(int8Min));
     expect(fetchedItems[1].tChar, equals(int8Max));
     expect(fetchedItems[2].tByte, equals(int8Min));
@@ -188,12 +191,13 @@ void main() {
       ...valsFloat.map((n) => TestEntity(tFloat: n)).toList(),
       ...valsDouble.map((n) => TestEntity(tDouble: n)).toList()
     ];
-    final List<TestEntity> fetchedItems = box.getMany(box.putMany(items));
+    final List<TestEntity> fetchedItems =
+        box.getMany(box.putMany(items)) as List<TestEntity /*!*/ >;
     List<double> fetchedVals = [];
     for (var i = 0; i < fetchedItems.length; i++) {
       fetchedVals.add(i < valsFloat.length
-          ? fetchedItems[i].tFloat
-          : fetchedItems[i].tDouble);
+          ? fetchedItems[i].tFloat /*!*/
+          : fetchedItems[i].tDouble /*!*/);
     }
 
     for (var i = 0; i < fetchedVals.length; i++) {
@@ -214,7 +218,8 @@ void main() {
       TestEntity(tLong: 10),
       TestEntity(tString: 'Hello')
     ];
-    final List<TestEntity> fetchedItems = box.getMany(box.putMany(items));
+    final List<TestEntity> fetchedItems =
+        box.getMany(box.putMany(items)) as List<TestEntity /*!*/ >;
     expect(fetchedItems[0].id, isNot(equals(null)));
     expect(fetchedItems[0].tLong, equals(null));
     expect(fetchedItems[0].tString, equals(null));
@@ -243,16 +248,17 @@ void main() {
         tChar: 'x'.codeUnitAt(0),
         tInt: 789012,
         tFloat: -2.71);
-    final fetchedItem = box.get(box.put(item));
+    final fetchedItem = box.get(box.put(item)) /*!*/;
     expect(fetchedItem.tString, equals('Hello'));
     expect(fetchedItem.tLong, equals(1234));
-    expect((fetchedItem.tDouble - 3.14159).abs(), lessThan(0.000000000001));
+    expect(
+        (fetchedItem.tDouble /*!*/ - 3.14159).abs(), lessThan(0.000000000001));
     expect(fetchedItem.tBool, equals(true));
     expect(fetchedItem.tByte, equals(123));
     expect(fetchedItem.tShort, equals(-4567));
     expect(fetchedItem.tChar, equals('x'.codeUnitAt(0)));
     expect(fetchedItem.tInt, equals(789012));
-    expect((fetchedItem.tFloat - (-2.71)).abs(), lessThan(0.0000001));
+    expect((fetchedItem.tFloat /*!*/ - (-2.71)).abs(), lessThan(0.0000001));
   });
 
   test('.count() works', () {
@@ -325,7 +331,8 @@ void main() {
     expect(box.count(), equals(4));
 
     // verify the right items were removed
-    final List<int> remainingIds = box.getAll().map((o) => o.id).toList();
+    final List<int /*?*/ > remainingIds =
+        box.getAll().map((o) => o.id).toList();
     expect(remainingIds, unorderedEquals(ids.sublist(0, 4)));
   });
 

--- a/test/entity.dart
+++ b/test/entity.dart
@@ -11,41 +11,41 @@ class TestingUnknownAnnotation {
 class TestEntity {
   @Id()
   @TestingUnknownAnnotation()
-  int/*?*/ id;
+  int /*?*/ id;
 
   // implicitly determined types
-  String/*?*/ tString;
-  int/*?*/ tLong;
-  double/*?*/ tDouble;
-  bool/*?*/ tBool;
+  String /*?*/ tString;
+  int /*?*/ tLong;
+  double /*?*/ tDouble;
+  bool /*?*/ tBool;
 
   @Transient()
-  int/*?*/ ignore;
+  int /*?*/ ignore;
 
   @Transient()
-  int/*?*/ omit, disregard;
+  int /*?*/ omit, disregard;
 
   // explicitly declared types, see OB-C, objectbox.h
 
   // OBXPropertyType.Byte | 1 byte
   @Property(type: 2)
-  int/*?*/ tByte;
+  int /*?*/ tByte;
 
   // OBXPropertyType.Short | 2 bytes
   @Property(type: 3)
-  int/*?*/ tShort;
+  int /*?*/ tShort;
 
   // OBXPropertyType.Char | 1 byte
   @Property(type: 4)
-  int/*?*/ tChar;
+  int /*?*/ tChar;
 
   // OBXPropertyType.Int |  ob: 4 bytes, dart: 8 bytes
   @Property(type: 5)
-  int/*?*/ tInt;
+  int /*?*/ tInt;
 
   // OBXPropertyType.Float | 4 bytes
   @Property(type: 7)
-  double/*?*/ tFloat;
+  double /*?*/ tFloat;
 
   TestEntity(
       {this.id,

--- a/test/entity.dart
+++ b/test/entity.dart
@@ -11,41 +11,41 @@ class TestingUnknownAnnotation {
 class TestEntity {
   @Id()
   @TestingUnknownAnnotation()
-  int id;
+  int/*?*/ id;
 
   // implicitly determined types
-  String tString;
-  int tLong;
-  double tDouble;
-  bool tBool;
+  String/*?*/ tString;
+  int/*?*/ tLong;
+  double/*?*/ tDouble;
+  bool/*?*/ tBool;
 
   @Transient()
-  int ignore;
+  int/*?*/ ignore;
 
   @Transient()
-  int omit, disregard;
+  int/*?*/ omit, disregard;
 
   // explicitly declared types, see OB-C, objectbox.h
 
   // OBXPropertyType.Byte | 1 byte
   @Property(type: 2)
-  int tByte;
+  int/*?*/ tByte;
 
   // OBXPropertyType.Short | 2 bytes
   @Property(type: 3)
-  int tShort;
+  int/*?*/ tShort;
 
   // OBXPropertyType.Char | 1 byte
   @Property(type: 4)
-  int tChar;
+  int/*?*/ tChar;
 
   // OBXPropertyType.Int |  ob: 4 bytes, dart: 8 bytes
   @Property(type: 5)
-  int tInt;
+  int/*?*/ tInt;
 
   // OBXPropertyType.Float | 4 bytes
   @Property(type: 7)
-  double tFloat;
+  double/*?*/ tFloat;
 
   TestEntity(
       {this.id,

--- a/test/entity2.dart
+++ b/test/entity2.dart
@@ -4,5 +4,5 @@ import 'package:objectbox/objectbox.dart';
 @Entity()
 class TestEntity2 {
   @Id()
-  int/*?*/ id;
+  int /*?*/ id;
 }

--- a/test/entity2.dart
+++ b/test/entity2.dart
@@ -4,5 +4,5 @@ import 'package:objectbox/objectbox.dart';
 @Entity()
 class TestEntity2 {
   @Id()
-  int id;
+  int/*?*/ id;
 }

--- a/test/observer_test.dart
+++ b/test/observer_test.dart
@@ -67,9 +67,9 @@ class Observable {
 }
 
 void main() async {
-  TestEnv env;
-  Box box;
-  Store store;
+  /*late final*/ TestEnv env;
+  /*late final*/ Box box;
+  /*late final*/ Store store;
 
   final testEntityId =
       getObjectBoxModel().model.findEntityByName('TestEntity').id.id;

--- a/test/query_property_test.dart
+++ b/test/query_property_test.dart
@@ -6,11 +6,11 @@ import 'objectbox.g.dart';
 import 'test_env.dart';
 
 void main() {
-  TestEnv env;
+  /*late final*/ TestEnv env;
 
   // TODO change to Box<TestEntity> box;
   //  breaks min/max functions below - can't be dynamic anymore
-  Box box;
+  /*late final*/ Box box;
 
   setUp(() {
     env = TestEnv('query_property');

--- a/test/query_property_test.dart
+++ b/test/query_property_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:objectbox/objectbox.dart';
 import 'package:test/test.dart';
 
@@ -147,11 +149,6 @@ void main() {
     query.close();
   });
 
-  final intLt = (int a, int b) => a < b ? a : b;
-  final intGt = (int a, int b) => a > b ? a : b;
-  final doubleLt = (double a, double b) => a < b ? a : b;
-  final doubleGt = (double a, double b) => a > b ? a : b;
-
   test('.min integers', () {
     box.putMany(integerList);
 
@@ -167,10 +164,10 @@ void main() {
 
     final all = box.getAll();
 
-    final minByte = all.map((s) => s.tByte).toList().reduce(intLt);
-    final minShort = all.map((s) => s.tShort).toList().reduce(intLt);
-    final minInt = all.map((s) => s.tInt).toList().reduce(intLt);
-    final minLong = all.map((s) => s.tLong).toList().reduce(intLt);
+    final minByte = all.map((s) => s.tByte).toList().reduce(min);
+    final minShort = all.map((s) => s.tShort).toList().reduce(min);
+    final minInt = all.map((s) => s.tInt).toList().reduce(min);
+    final minLong = all.map((s) => s.tLong).toList().reduce(min);
 
     expect(propMin(tByte), minByte);
     expect(propMin(tShort), minShort);
@@ -195,10 +192,10 @@ void main() {
 
     final all = box.getAll();
 
-    final maxByte = all.map((s) => s.tByte).toList().reduce(intGt);
-    final maxShort = all.map((s) => s.tShort).toList().reduce(intGt);
-    final maxInt = all.map((s) => s.tInt).toList().reduce(intGt);
-    final maxLong = all.map((s) => s.tLong).toList().reduce(intGt);
+    final maxByte = all.map((s) => s.tByte).toList().reduce(max);
+    final maxShort = all.map((s) => s.tShort).toList().reduce(max);
+    final maxInt = all.map((s) => s.tInt).toList().reduce(max);
+    final maxLong = all.map((s) => s.tLong).toList().reduce(max);
 
     expect(propMax(tByte), maxByte);
     expect(propMax(tShort), maxShort);
@@ -247,8 +244,8 @@ void main() {
 
     final all = box.getAll();
 
-    final minFloat = all.map((s) => s.tFloat).toList().reduce(doubleLt);
-    final minDouble = all.map((s) => s.tDouble).toList().reduce(doubleLt);
+    final minFloat = all.map((s) => s.tFloat).toList().reduce(min);
+    final minDouble = all.map((s) => s.tDouble).toList().reduce(min);
 
     expect(propMin(tFloat), minFloat);
     expect(propMin(tDouble), minDouble);
@@ -271,8 +268,8 @@ void main() {
 
     final all = box.getAll();
 
-    final maxFloat = all.map((s) => s.tFloat).toList().reduce(doubleGt);
-    final maxDouble = all.map((s) => s.tDouble).toList().reduce(doubleGt);
+    final maxFloat = all.map((s) => s.tFloat).toList().reduce(max);
+    final maxDouble = all.map((s) => s.tDouble).toList().reduce(max);
 
     expect(propMax(tFloat), maxFloat);
     expect(propMax(tDouble), maxDouble);

--- a/test/query_property_test.dart
+++ b/test/query_property_test.dart
@@ -7,10 +7,8 @@ import 'test_env.dart';
 
 void main() {
   /*late final*/ TestEnv env;
-
-  // TODO change to Box<TestEntity> box;
-  //  breaks min/max functions below - can't be dynamic anymore
-  /*late final*/ Box box;
+  /*late final*/
+  Box<TestEntity> box;
 
   setUp(() {
     env = TestEnv('query_property');
@@ -149,7 +147,11 @@ void main() {
     query.close();
   });
 
-  final min = (a, b) => a < b ? a : b;
+  final intLt = (int a, int b) => a < b ? a : b;
+  final intGt = (int a, int b) => a > b ? a : b;
+  final doubleLt = (double a, double b) => a < b ? a : b;
+  final doubleGt = (double a, double b) => a > b ? a : b;
+
   test('.min integers', () {
     box.putMany(integerList);
 
@@ -165,10 +167,10 @@ void main() {
 
     final all = box.getAll();
 
-    final minByte = all.map((s) => s.tByte).toList().reduce(min);
-    final minShort = all.map((s) => s.tShort).toList().reduce(min);
-    final minInt = all.map((s) => s.tInt).toList().reduce(min);
-    final minLong = all.map((s) => s.tLong).toList().reduce(min);
+    final minByte = all.map((s) => s.tByte).toList().reduce(intLt);
+    final minShort = all.map((s) => s.tShort).toList().reduce(intLt);
+    final minInt = all.map((s) => s.tInt).toList().reduce(intLt);
+    final minLong = all.map((s) => s.tLong).toList().reduce(intLt);
 
     expect(propMin(tByte), minByte);
     expect(propMin(tShort), minShort);
@@ -178,7 +180,6 @@ void main() {
     query.close();
   });
 
-  final max = (a, b) => a > b ? a : b;
   test('.max integers', () {
     box.putMany(integerList);
 
@@ -194,10 +195,10 @@ void main() {
 
     final all = box.getAll();
 
-    final maxByte = all.map((s) => s.tByte).toList().reduce(max);
-    final maxShort = all.map((s) => s.tShort).toList().reduce(max);
-    final maxInt = all.map((s) => s.tInt).toList().reduce(max);
-    final maxLong = all.map((s) => s.tLong).toList().reduce(max);
+    final maxByte = all.map((s) => s.tByte).toList().reduce(intGt);
+    final maxShort = all.map((s) => s.tShort).toList().reduce(intGt);
+    final maxInt = all.map((s) => s.tInt).toList().reduce(intGt);
+    final maxLong = all.map((s) => s.tLong).toList().reduce(intGt);
 
     expect(propMax(tByte), maxByte);
     expect(propMax(tShort), maxShort);
@@ -246,8 +247,8 @@ void main() {
 
     final all = box.getAll();
 
-    final minFloat = all.map((s) => s.tFloat).toList().reduce(min);
-    final minDouble = all.map((s) => s.tDouble).toList().reduce(min);
+    final minFloat = all.map((s) => s.tFloat).toList().reduce(doubleLt);
+    final minDouble = all.map((s) => s.tDouble).toList().reduce(doubleLt);
 
     expect(propMin(tFloat), minFloat);
     expect(propMin(tDouble), minDouble);
@@ -270,8 +271,8 @@ void main() {
 
     final all = box.getAll();
 
-    final maxFloat = all.map((s) => s.tFloat).toList().reduce(max);
-    final maxDouble = all.map((s) => s.tDouble).toList().reduce(max);
+    final maxFloat = all.map((s) => s.tFloat).toList().reduce(doubleGt);
+    final maxDouble = all.map((s) => s.tDouble).toList().reduce(doubleGt);
 
     expect(propMax(tFloat), maxFloat);
     expect(propMax(tDouble), maxDouble);

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -8,7 +8,7 @@ import 'objectbox.g.dart';
 
 void main() {
   /*late final*/ TestEnv env;
-  /*late final*/ Box box;
+  /*late final*/ Box<TestEntity> box;
 
   setUp(() {
     env = TestEnv('query');
@@ -16,7 +16,7 @@ void main() {
   });
 
   test('Query with no conditions, and order as desc ints', () {
-    box.putMany([
+    box.putMany(<TestEntity>[
       TestEntity(tInt: 0),
       TestEntity(tInt: 10),
       TestEntity(tInt: 100),
@@ -63,7 +63,7 @@ void main() {
   });
 
   test('.null and .notNull', () {
-    box.putMany([
+    box.putMany(<TestEntity>[
       TestEntity(tDouble: 0.1, tBool: true),
       TestEntity(tDouble: 0.3, tBool: false),
       TestEntity(tString: 'one'),
@@ -87,7 +87,7 @@ void main() {
   });
 
   test('.count doubles and booleans', () {
-    box.putMany([
+    box.putMany(<TestEntity>[
       TestEntity(tDouble: 0.1, tBool: true),
       TestEntity(tDouble: 0.3, tBool: false),
       TestEntity(tDouble: 0.5, tBool: true),
@@ -135,7 +135,7 @@ void main() {
   });
 
   test('.count matches of `greater` and `less`', () {
-    box.putMany([
+    box.putMany(<TestEntity>[
       TestEntity(tLong: 1336, tString: 'mord'),
       TestEntity(tLong: 1337, tString: 'more'),
       TestEntity(tLong: 1338, tString: 'morf'),

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -7,8 +7,8 @@ import 'objectbox.g.dart';
 // ignore_for_file: omit_local_variable_types
 
 void main() {
-  TestEnv env;
-  Box<TestEntity> box;
+  /*late final*/ TestEnv env;
+  /*late final*/ Box box;
 
   setUp(() {
     env = TestEnv('query');

--- a/test/stream_test.dart
+++ b/test/stream_test.dart
@@ -11,7 +11,8 @@ import 'test_env.dart';
 
 void main() {
   /*late final*/ TestEnv env;
-  /*late final*/ Box box;
+  /*late final*/
+  Box<TestEntity> box;
 
   setUp(() {
     env = TestEnv('streams');
@@ -31,10 +32,9 @@ void main() {
 
     box.put(TestEntity(tString: 'Hello world'));
 
-    // The delay is here to ensure that the
-    // callback execution is executed sequentially,
-    // otherwise the testing framework's execution
-    // will be prioritized (for some reason), before any callback.
+    // The delay is here to ensure that the callback execution is executed
+    // sequentially, otherwise the testing framework's execution  will be
+    // prioritized (for some reason), before any callback.
     await Future.delayed(Duration(seconds: 0));
 
     box.putMany(<TestEntity>[

--- a/test/stream_test.dart
+++ b/test/stream_test.dart
@@ -10,8 +10,8 @@ import 'test_env.dart';
 // ignore_for_file: non_constant_identifier_names
 
 void main() {
-  TestEnv env;
-  Box box;
+  /*late final*/ TestEnv env;
+  /*late final*/ Box box;
 
   setUp(() {
     env = TestEnv('streams');

--- a/test/sync_test.dart
+++ b/test/sync_test.dart
@@ -106,9 +106,9 @@ void main() {
 
       // But we can still get a handle of the client in the store - we're never
       // completely without an option to close it.
-      final client = store.syncClient();
+      SyncClient /*?*/ client = store.syncClient();
       expect(client, isNotNull);
-      expect(client.isClosed(), isFalse);
+      expect(client /*!*/ .isClosed(), isFalse);
       client.close();
       expect(store.syncClient(), isNull);
     });
@@ -184,10 +184,12 @@ void main() {
       int id = env.box.put(TestEntity(tLong: Random().nextInt(1 << 32)));
       expect(waitUntil(() => env2.box.get(id) != null), isTrue);
 
-      final read1 = env.box.get(id);
-      final read2 = env2.box.get(id);
-      expect(read1.id, equals(read2.id));
-      expect(read1.tLong, equals(read2.tLong));
+      TestEntity /*?*/ read1 = env.box.get(id);
+      TestEntity /*?*/ read2 = env2.box.get(id);
+      expect(read1, isNotNull);
+      expect(read2, isNotNull);
+      expect(read1 /*!*/ .id, equals(read2 /*!*/ .id));
+      expect(read1 /*!*/ .tLong, equals(read2 /*!*/ .tLong));
     },
         // Note: only available when you start a sync server manually.
         // Comment out the `skip: ` argument in tthe test-case definition.

--- a/test/sync_test.dart
+++ b/test/sync_test.dart
@@ -14,8 +14,8 @@ import 'test_env.dart';
 // ignore_for_file: omit_local_variable_types
 
 void main() {
-  TestEnv env;
-  Store store;
+  /*late final*/ TestEnv env;
+  /*late final*/ Store store;
 
   setUp(() {
     env = TestEnv('sync');

--- a/test/test_env.dart
+++ b/test/test_env.dart
@@ -4,8 +4,8 @@ import 'objectbox.g.dart';
 
 class TestEnv {
   final Directory dir;
-  Store store;
-  Box<TestEntity> box;
+  /*late final*/ Store store;
+  /*late final*/ Box<TestEntity> box;
 
   TestEnv(String name) : dir = Directory('testdata-' + name) {
     if (dir.existsSync()) dir.deleteSync(recursive: true);


### PR DESCRIPTION
The first step of introducing null-safety. See #149 

This PR adds "hints" for the [null-safety migration tool](https://dart.dev/null-safety/migration-guide#migration-tool) but doesn't yet apply the changes (it can only be done once). 

Additionally to the hints, some code has been changed to avoid using nullable types altogether, including some (potential) bug fixes.

My idea is to merge this into main now without null-safety enabled, because the changes here shouldn't be breaking (or not much more than usual)