### PR TITLE
Fix Stream issue #151, with @RTrackerDev's suggestions

### DIFF
--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -1,10 +1,4 @@
-import 'dart:async';
-import 'dart:ffi';
-
-import 'bindings/bindings.dart';
-import 'bindings/signatures.dart';
-import 'query/query.dart';
-import 'store.dart';
+part of 'query/query.dart';
 
 // ignore_for_file: non_constant_identifier_names
 
@@ -20,15 +14,17 @@ class Observable {
 
   // The user_data is used to pass the store ptr address
   // in case there is no consensus on the entity id between stores
-  static void _anyCallback(
-      Pointer<Void> user_data, Pointer<Uint32> mutated_ids, int mutated_count) {
+  static void _anyCallback(Pointer<Void> user_data,
+      Pointer<Uint32> mutated_entity_ids, int mutated_count) {
     final storeAddress = user_data.address;
     for (var i = 0; i < mutated_count; i++) {
       // call schema's callback
       if (_any.containsKey(storeAddress) &&
-          _any[storeAddress].containsKey(mutated_ids[i])) {
-        _any[storeAddress]
-            [mutated_ids[i]](user_data, mutated_ids, mutated_count);
+          _any[storeAddress].containsKey(mutated_entity_ids[i])) {
+        _any[storeAddress][mutated_entity_ids[i]](
+            user_data, mutated_entity_ids, mutated_count);
+        print([user_data.address, mutated_entity_ids[i], mutated_count]
+            .join(','));
       }
     }
   }
@@ -63,10 +59,10 @@ extension ObservableStore on Store {
 
 extension Streamable<T> on Query<T> {
   void _setup() {
-    final storePtr = store.ptr;
+    final storePtr = _store.ptr;
 
     if (!Observable._anyObserver.containsKey(storePtr)) {
-      store.subscribe();
+      _store.subscribe();
     }
 
     final storeAddress = storePtr.address;

--- a/lib/src/query/query.dart
+++ b/lib/src/query/query.dart
@@ -1,5 +1,6 @@
 library query;
 
+import 'dart:async';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart' show allocate, free, Utf8;
 
@@ -15,6 +16,7 @@ import '../bindings/signatures.dart';
 
 part 'builder.dart';
 part 'property.dart';
+part '../observable.dart';
 
 class Order {
   /// Reverts the order from ascending (default) to descending.
@@ -571,12 +573,12 @@ class ConditionGroupAll extends ConditionGroup {
 /// Use [property] to only return values or an aggregate of a single Property.
 class Query<T> {
   Pointer<Void> _cQuery;
-  Store store;
+  final Store _store;
   final OBXFlatbuffersManager _fbManager;
   int entityId;
 
   // package private ctor
-  Query._(this.store, this._fbManager, Pointer<Void> cBuilder, this.entityId) {
+  Query._(this._store, this._fbManager, Pointer<Void> cBuilder, this.entityId) {
     _cQuery = checkObxPtr(bindings.obx_query_create(cBuilder), 'create query');
   }
 
@@ -662,7 +664,7 @@ class Query<T> {
     if (limit > 0) {
       this.limit(limit);
     }
-    return store.runInTransaction(TxMode.Read, () {
+    return _store.runInTransaction(TxMode.Read, () {
       if (bindings.obx_supports_bytes_array() == 1) {
         final bytesArray =
             checkObxPtr(bindings.obx_query_find(_cQuery), 'find');

--- a/test/stream_test.dart
+++ b/test/stream_test.dart
@@ -98,6 +98,13 @@ void main() {
       counter1++;
     });
 
+    // bug found: the number of listeners increases
+    // the number of notifications
+    final queryStream3 = query1.findStream();
+    final subscription3 = queryStream3.listen((_) {
+      // dummy to trigger
+    });
+
     // counter2 test #1
     final t2 = TestEntity2();
     box2.put(t2);

--- a/test/stream_test.dart
+++ b/test/stream_test.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
-import 'package:objectbox/src/observable.dart';
 import 'package:test/test.dart';
 
 import 'entity.dart';
+import 'entity2.dart';
 import 'objectbox.g.dart';
 import 'test_env.dart';
 
@@ -76,5 +76,64 @@ void main() {
   tearDown(() {
     env.store.unsubscribe();
     env.close();
+  });
+
+  test(
+      'Only observers of a single entity are notified, no cross-entity notification',
+      () async {
+    // setup listeners
+    final box2 = Box<TestEntity2>(env.store);
+
+    var counter1 = 0, counter2 = 0;
+
+    final query2 = box2.query().build();
+    final queryStream2 = query2.findStream();
+    final subscription2 = queryStream2.listen((_) {
+      counter2++;
+    });
+
+    final query1 = box.query().build();
+    final queryStream1 = query1.findStream();
+    final subscription1 = queryStream1.listen((_) {
+      counter1++;
+    });
+
+    // counter2 test #1
+    final t2 = TestEntity2();
+    box2.put(t2);
+
+    await Future.delayed(Duration(seconds: 0));
+    expect(counter1, 0);
+    expect(counter2, 1);
+
+    // counter1 test #1
+    final t1 = TestEntity();
+    box.put(t1);
+
+    await Future.delayed(Duration(seconds: 0));
+    expect(counter1, 1);
+    expect(counter2, 1);
+
+    // counter1 many test #2
+    final ts1 = [1, 2, 3].map((i) => TestEntity(tInt: i)).toList();
+    box.putMany(ts1);
+
+    await Future.delayed(Duration(seconds: 0));
+    expect(counter1, 2);
+    expect(counter2, 1);
+
+    // counter2 many test #2
+    final ts2 = [1, 2, 3].map((i) => TestEntity2()).toList();
+    box2.putMany(ts2);
+
+    await Future.delayed(Duration(seconds: 0));
+    expect(counter1, 2);
+    expect(counter2, 2);
+
+    query1.close();
+    query2.close();
+
+    await subscription1.cancel();
+    await subscription2.cancel();
   });
 }


### PR DESCRIPTION
* add non-cross entity notification test
* made Query.store -> Query._store package private again
* one C observer callback per store, killed another bug
* add @RTrackerDev's fix