### PR TITLE
example/README: Fix typo in comment

### DIFF
--- a/objectbox/example/README.md
+++ b/objectbox/example/README.md
@@ -118,7 +118,7 @@ import 'objectbox.g.dart';
 
 final box = store.box<Note>();
 
-final note = Note(text: 'Hello'); // note: node.id is null
+final note = Note(text: 'Hello'); // note: note.id is null
 final id = box.put(note);         // note: sets note.id and also returns it
 print('new note got id=${id}, which is the same as note.id=${note.id}');
 print('refetched note: ${box.get(id)}');


### PR DESCRIPTION
The variable is named 'note' and not 'node'. Reflect same in the comment.

Signed-off-by: Aayush Gupta <aayushgupta219@gmail.com>