### PR TITLE
Add missing PutMode enum export

### DIFF
--- a/objectbox/lib/objectbox.dart
+++ b/objectbox/lib/objectbox.dart
@@ -6,7 +6,7 @@
 library objectbox;
 
 export 'src/annotations.dart';
-export 'src/box.dart' show Box;
+export 'src/box.dart' show Box, PutMode;
 export 'src/common.dart';
 export 'src/observable.dart';
 export 'src/query.dart'


### PR DESCRIPTION
Now it is not possible to pass the `mode` argument to `put` or `putMany` due to missing export.