### PR TITLE
Generated code changes

### DIFF
--- a/benchmark/bin/basics.dart
+++ b/benchmark/bin/basics.dart
@@ -1,0 +1,13 @@
+import 'package:objectbox_benchmark/benchmark.dart';
+import 'package:objectbox_benchmark/objectbox.g.dart';
+
+void main() {
+  ModelInit().report();
+}
+
+class ModelInit extends Benchmark {
+  ModelInit() : super('${ModelInit}', iterations: 1000);
+
+  @override
+  void runIteration(int i) => getObjectBoxModel();
+}

--- a/generator/lib/src/code_builder.dart
+++ b/generator/lib/src/code_builder.dart
@@ -69,7 +69,7 @@ class CodeBuilder extends Builder {
           ModelInfo.fromMap(json.decode(await buildStep.readAsString(jsonId)));
     } else {
       log.warning('Creating model: ${jsonId.path}');
-      model = ModelInfo();
+      model = ModelInfo.empty();
     }
 
     // merge existing model and annotated model that was just read, then write new final model to file

--- a/generator/lib/src/code_chunks.dart
+++ b/generator/lib/src/code_chunks.dart
@@ -10,8 +10,6 @@ class CodeChunks {
   static String objectboxDart(ModelInfo model, List<String> imports) => """
     // GENERATED CODE - DO NOT MODIFY BY HAND
     
-    // Currently loading model from "JSON" which always encodes with double quotes
-    // ignore_for_file: prefer_single_quotes
     // ignore_for_file: camel_case_types
     
     import 'dart:typed_data';
@@ -25,10 +23,11 @@ class CodeChunks {
     export 'package:objectbox/objectbox.dart'; // so that callers only have to import this file
     
     ModelDefinition getObjectBoxModel() {
-      final model = ModelInfo.fromMap(${JsonEncoder().convert(model.toMap())}, check: false);
+      ${defineModel(model)}
       
-      final bindings = <Type, EntityDefinition>{};
-      ${model.entities.map((entity) => "bindings[${entity.name}] = ${entityBinding(entity)};").join("\n")} 
+      final bindings = <Type, EntityDefinition>{
+        ${model.entities.mapIndexed((i, entity) => "${entity.name}: ${entityBinding(i, entity)}").join(",\n")}
+      };
       
       return ModelDefinition(model, bindings);
     }
@@ -41,11 +40,97 @@ class CodeChunks {
     return list;
   }
 
-  static String entityBinding(ModelEntity entity) {
+  static String defineModel(ModelInfo model) {
+    return '''
+    final entities = List<ModelEntity>.unmodifiable([
+      ${model.entities.map(createModelEntity).join(',')}
+    ]);
+    
+    final model = ModelInfo(
+      entities: entities,
+      lastEntityId: ${createIdUid(model.lastEntityId)},
+      lastIndexId: ${createIdUid(model.lastIndexId)},
+      lastRelationId: ${createIdUid(model.lastRelationId)},
+      lastSequenceId: ${createIdUid(model.lastSequenceId)},
+      retiredEntityUids: const ${model.retiredEntityUids},
+      retiredIndexUids: const ${model.retiredIndexUids},
+      retiredPropertyUids: const ${model.retiredPropertyUids},
+      retiredRelationUids: const ${model.retiredRelationUids},
+      modelVersion: ${model.modelVersion},
+      modelVersionParserMinimum: ${model.modelVersionParserMinimum},
+      version: ${model.version});
+    ''';
+  }
+
+  static String createIdUid(IdUid value) {
+    return 'const IdUid(${value.id}, ${value.uid})';
+  }
+
+  static String createModelEntity(ModelEntity entity) {
+    return '''
+    ModelEntity(
+      id: ${createIdUid(entity.id)}, 
+      name: '${entity.name}', 
+      lastPropertyId: ${createIdUid(entity.lastPropertyId)}, 
+      flags: ${entity.flags}, 
+      properties: List<ModelProperty>.unmodifiable([
+        ${entity.properties.map(createModelProperty).join(',')}
+      ]), 
+      relations: List<ModelRelation>.unmodifiable([
+        ${entity.relations.map(createModelRelation).join(',')}
+      ]), 
+      backlinks: List<ModelBacklink>.unmodifiable([
+        ${entity.backlinks.map(createModelBacklink).join(',')}
+      ])
+    )
+    ''';
+  }
+
+  static String createModelProperty(ModelProperty property) {
+    var additionalArgs = '';
+    if (property.indexId != null && !property.indexId!.isEmpty) {
+      additionalArgs += ', indexId: ${createIdUid(property.indexId!)}';
+    }
+    if (property.relationTarget != null &&
+        property.relationTarget!.isNotEmpty) {
+      additionalArgs += ", relationTarget: '${property.relationTarget!}'";
+    }
+    return '''
+    ModelProperty(
+      id: ${createIdUid(property.id)}, 
+      name: '${property.name}', 
+      type: ${property.type}, 
+      flags: ${property.flags}
+      $additionalArgs
+    )
+    ''';
+  }
+
+  static String createModelRelation(ModelRelation relation) {
+    return '''
+    ModelRelation(
+      id: ${createIdUid(relation.id)}, 
+      name: '${relation.name}', 
+      targetId: ${createIdUid(relation.targetId)}
+    )
+    ''';
+  }
+
+  static String createModelBacklink(ModelBacklink backlink) {
+    return '''
+    ModelBacklink(
+      name: '${backlink.name}', 
+      srcEntity: '${backlink.srcEntity}', 
+      srcField: '${backlink.srcField}'
+    )
+    ''';
+  }
+
+  static String entityBinding(int i, ModelEntity entity) {
     final name = entity.name;
     return '''
       EntityDefinition<$name>(
-        model: model.getEntityByUid(${entity.id.uid}),
+        model: entities[$i],
         toOneRelations: ($name object) => ${toOneRelations(entity)},
         toManyRelations: ($name object) => ${toManyRelations(entity)},
         getId: ($name object) => object.${propertyFieldName(entity.idProperty)},

--- a/generator/lib/src/code_chunks.dart
+++ b/generator/lib/src/code_chunks.dart
@@ -42,9 +42,9 @@ class CodeChunks {
 
   static String defineModel(ModelInfo model) {
     return '''
-    final entities = List<ModelEntity>.unmodifiable([
+    final entities = <ModelEntity>[
       ${model.entities.map(createModelEntity).join(',')}
-    ]);
+    ];
     
     final model = ModelInfo(
       entities: entities,
@@ -73,15 +73,15 @@ class CodeChunks {
       name: '${entity.name}', 
       lastPropertyId: ${createIdUid(entity.lastPropertyId)}, 
       flags: ${entity.flags}, 
-      properties: List<ModelProperty>.unmodifiable([
+      properties: <ModelProperty>[
         ${entity.properties.map(createModelProperty).join(',')}
-      ]), 
-      relations: List<ModelRelation>.unmodifiable([
+      ], 
+      relations: <ModelRelation>[
         ${entity.relations.map(createModelRelation).join(',')}
-      ]), 
-      backlinks: List<ModelBacklink>.unmodifiable([
+      ], 
+      backlinks: <ModelBacklink>[
         ${entity.backlinks.map(createModelBacklink).join(',')}
-      ])
+      ]
     )
     ''';
   }

--- a/objectbox/example/flutter/objectbox_demo/lib/main.dart
+++ b/objectbox/example/flutter/objectbox_demo/lib/main.dart
@@ -53,7 +53,7 @@ class ViewModel {
       : _store =
             Store(getObjectBoxModel(), directory: dir.path + '/objectbox') {
     _box = Box<Note>(_store);
-    _query = _box.query().order(Note_.date, flags: Order.descending).build();
+    _query = (_box.query()..order(Note_.date, flags: Order.descending)).build();
   }
 
   void addNote(Note note) => _box.put(note);

--- a/objectbox/example/flutter/objectbox_demo_sync/lib/main.dart
+++ b/objectbox/example/flutter/objectbox_demo_sync/lib/main.dart
@@ -54,7 +54,7 @@ class ViewModel {
       : _store = Store(getObjectBoxModel(),
             directory: dir.path + '/objectbox-sync') {
     _box = Box<Note>(_store);
-    _query = _box.query().order(Note_.date, flags: Order.descending).build();
+    _query = (_box.query()..order(Note_.date, flags: Order.descending)).build();
 
     // TODO configure actual sync server address and authentication
     // For configuration and docs, see objectbox/lib/src/sync.dart

--- a/objectbox/lib/integration_test.dart
+++ b/objectbox/lib/integration_test.dart
@@ -19,10 +19,10 @@ class IntegrationTest {
 
   static void model() {
     // create a model with a single entity and a single property
-    final modelInfo = ModelInfo();
-    final property =
-        ModelProperty(IdUid(1, int64Max - 1), 'id', OBXPropertyType.Long);
-    final entity = ModelEntity(IdUid(1, int64Max), 'entity', modelInfo);
+    final modelInfo = ModelInfo.empty();
+    final property = ModelProperty.create(
+        IdUid(1, int64Max - 1), 'id', OBXPropertyType.Long);
+    final entity = ModelEntity.create(IdUid(1, int64Max), 'entity', modelInfo);
     property.entity = entity;
     entity.properties.add(property);
     entity.lastPropertyId = property.id;

--- a/objectbox/lib/integration_test.dart
+++ b/objectbox/lib/integration_test.dart
@@ -21,8 +21,9 @@ class IntegrationTest {
     // create a model with a single entity and a single property
     final modelInfo = ModelInfo.empty();
     final property = ModelProperty.create(
-        IdUid(1, int64Max - 1), 'id', OBXPropertyType.Long);
-    final entity = ModelEntity.create(IdUid(1, int64Max), 'entity', modelInfo);
+        const IdUid(1, int64Max - 1), 'id', OBXPropertyType.Long);
+    final entity =
+        ModelEntity.create(const IdUid(1, int64Max), 'entity', modelInfo);
     property.entity = entity;
     entity.properties.add(property);
     entity.lastPropertyId = property.id;

--- a/objectbox/lib/src/modelinfo/iduid.dart
+++ b/objectbox/lib/src/modelinfo/iduid.dart
@@ -8,48 +8,34 @@
 ///  * [IDs](https://docs.objectbox.io/advanced/meta-model-ids-and-uids#ids)
 ///  * [UIDs](https://docs.objectbox.io/advanced/meta-model-ids-and-uids#uids)
 class IdUid {
-  late int _id, _uid;
+  final int id, uid;
 
-  int get id => _id;
+  const IdUid(this.id, this.uid);
 
-  set id(int id) {
-    RangeError.checkValueInInterval(id, 0, ((1 << 63) - 1), 'id');
-    _id = id;
-  }
-
-  int get uid => _uid;
-
-  set uid(int uid) {
-    RangeError.checkValueInInterval(uid, 0, ((1 << 63) - 1), 'uid');
-    _uid = uid;
-  }
-
-  IdUid(int newId, int newUid) {
-    id = newId;
-    uid = newUid;
-  }
-
-  IdUid.fromString(String? str) {
+  factory IdUid.fromString(String? str) {
     if (str == null || str == '' || str == '0:0') {
-      _id = 0;
-      _uid = 0;
-      return;
+      return const IdUid.empty();
     }
 
     final spl = str.split(':');
     if (spl.length != 2) {
       throw ArgumentError.value(str, 'str', 'IdUid has invalid format');
     }
-    id = int.parse(spl[0]);
-    uid = int.parse(spl[1]);
+    return IdUid(_parse('id', spl[0]), _parse('uid', spl[1]));
   }
 
-  IdUid.empty()
-      : _id = 0,
-        _uid = 0;
+  const IdUid.empty()
+      : id = 0,
+        uid = 0;
 
-  bool get isEmpty => _id == 0 && _uid == 0;
+  bool get isEmpty => id == 0 && uid == 0;
 
   @override
-  String toString() => '$_id:$_uid';
+  String toString() => '$id:$uid';
+
+  static int _parse(String name, String part) {
+    final value = int.parse(part);
+    RangeError.checkValueInInterval(value, 0, ((1 << 63) - 1), name);
+    return value;
+  }
 }

--- a/objectbox/lib/src/modelinfo/modelbacklink.dart
+++ b/objectbox/lib/src/modelinfo/modelbacklink.dart
@@ -8,11 +8,14 @@ class ModelBacklink {
 
   final String srcField;
 
-  ModelBacklink(this.name, this.srcEntity, this.srcField);
+  ModelBacklink(
+      {required this.name, required this.srcEntity, required this.srcField});
 
   ModelBacklink.fromMap(Map<String, dynamic> data)
-      : this(data['name'] as String, data['srcEntity'] as String,
-            data['srcField'] as String);
+      : this(
+            name: data['name'] as String,
+            srcEntity: data['srcEntity'] as String,
+            srcField: data['srcField'] as String);
 
   Map<String, String> toMap() =>
       {'name': name, 'srcEntity': srcEntity, 'srcField': srcField};

--- a/objectbox/lib/src/modelinfo/modelentity.dart
+++ b/objectbox/lib/src/modelinfo/modelentity.dart
@@ -12,7 +12,7 @@ class ModelEntity {
   IdUid id;
 
   late String _name;
-  IdUid lastPropertyId = IdUid.empty();
+  IdUid lastPropertyId = const IdUid.empty();
   int _flags = 0;
   final List<ModelProperty> _properties;
   final List<ModelRelation> _relations;

--- a/objectbox/lib/src/modelinfo/modelentity.dart
+++ b/objectbox/lib/src/modelinfo/modelentity.dart
@@ -14,9 +14,9 @@ class ModelEntity {
   late String _name;
   IdUid lastPropertyId = IdUid.empty();
   int _flags = 0;
-  final _properties = <ModelProperty>[];
-  final _relations = <ModelRelation>[];
-  final _backlinks = <ModelBacklink>[];
+  final List<ModelProperty> _properties;
+  final List<ModelRelation> _relations;
+  final List<ModelBacklink> _backlinks;
   ModelProperty? _idProperty;
   final ModelInfo? _model;
 
@@ -59,17 +59,37 @@ class ModelEntity {
 
   List<ModelBacklink> get backlinks => _backlinks;
 
-  ModelEntity(this.id, String? name, this._model) {
-    this.name = name;
-    validate();
-  }
+  // used in code generator
+  ModelEntity.create(this.id, this._name, this._model)
+      : _properties = [],
+        _relations = [],
+        _backlinks = [];
+
+  // used in generated code
+  ModelEntity(
+      {required this.id,
+      required String name,
+      required this.lastPropertyId,
+      required int flags,
+      required List<ModelProperty> properties,
+      required List<ModelRelation> relations,
+      required List<ModelBacklink> backlinks})
+      : _name = name,
+        _flags = flags,
+        _properties = properties,
+        _relations = relations,
+        _backlinks = backlinks,
+        _model = null;
 
   ModelEntity.fromMap(Map<String, dynamic> data,
       {ModelInfo? model, bool check = true})
       : _model = model,
         id = IdUid.fromString(data['id'] as String?),
         lastPropertyId = IdUid.fromString(data['lastPropertyId'] as String?),
-        nullSafetyEnabled = data['nullSafetyEnabled'] as bool? ?? true {
+        nullSafetyEnabled = data['nullSafetyEnabled'] as bool? ?? true,
+        _properties = [],
+        _relations = [],
+        _backlinks = [] {
     name = data['name'] as String?;
     flags = data['flags'] as int? ?? 0;
 
@@ -191,7 +211,8 @@ class ModelEntity {
     }
     final uniqueUid = uid == 0 ? model.generateUid() : uid;
 
-    final property = ModelProperty(IdUid(id, uniqueUid), name, 0, entity: this);
+    final property =
+        ModelProperty.create(IdUid(id, uniqueUid), name, 0, entity: this);
     properties.add(property);
     lastPropertyId = property.id;
 
@@ -242,7 +263,7 @@ class ModelEntity {
     }
     final uniqueUid = uid == 0 ? model.generateUid() : uid;
 
-    final relation = ModelRelation(IdUid(id, uniqueUid), name);
+    final relation = ModelRelation.create(IdUid(id, uniqueUid), name);
     relations.add(relation);
     model.lastRelationId = relation.id;
 

--- a/objectbox/lib/src/modelinfo/modelinfo.dart
+++ b/objectbox/lib/src/modelinfo/modelinfo.dart
@@ -44,10 +44,10 @@ class ModelInfo {
 
   ModelInfo.empty()
       : entities = [],
-        lastEntityId = IdUid.empty(),
-        lastIndexId = IdUid.empty(),
-        lastRelationId = IdUid.empty(),
-        lastSequenceId = IdUid.empty(),
+        lastEntityId = const IdUid.empty(),
+        lastIndexId = const IdUid.empty(),
+        lastRelationId = const IdUid.empty(),
+        lastSequenceId = const IdUid.empty(),
         retiredEntityUids = [],
         retiredIndexUids = [],
         retiredPropertyUids = [],

--- a/objectbox/lib/src/modelinfo/modelinfo.dart
+++ b/objectbox/lib/src/modelinfo/modelinfo.dart
@@ -28,7 +28,21 @@ class ModelInfo {
       retiredRelationUids;
   int modelVersion, modelVersionParserMinimum, version;
 
-  ModelInfo()
+  ModelInfo(
+      {required this.entities,
+      required this.lastEntityId,
+      required this.lastIndexId,
+      required this.lastRelationId,
+      required this.lastSequenceId,
+      required this.retiredEntityUids,
+      required this.retiredIndexUids,
+      required this.retiredPropertyUids,
+      required this.retiredRelationUids,
+      required this.modelVersion,
+      required this.modelVersionParserMinimum,
+      required this.version});
+
+  ModelInfo.empty()
       : entities = [],
         lastEntityId = IdUid.empty(),
         lastIndexId = IdUid.empty(),
@@ -187,7 +201,7 @@ class ModelInfo {
     }
     final uniqueUid = uid == 0 ? generateUid() : uid;
 
-    var entity = ModelEntity(IdUid(id, uniqueUid), name, this);
+    var entity = ModelEntity.create(IdUid(id, uniqueUid), name, this);
     entities.add(entity);
     lastEntityId = entity.id;
     return entity;

--- a/objectbox/lib/src/modelinfo/modelproperty.dart
+++ b/objectbox/lib/src/modelinfo/modelproperty.dart
@@ -111,7 +111,7 @@ class ModelProperty {
       : _name = name,
         _type = type,
         _flags = flags,
-        _indexId = indexId {}
+        _indexId = indexId;
 
   ModelProperty.fromMap(Map<String, dynamic> data, ModelEntity? entity)
       : this.create(IdUid.fromString(data['id'] as String?),

--- a/objectbox/lib/src/modelinfo/modelproperty.dart
+++ b/objectbox/lib/src/modelinfo/modelproperty.dart
@@ -86,7 +86,8 @@ class ModelProperty {
     _indexId = value;
   }
 
-  ModelProperty(this.id, String? name, int? type,
+  // used in code generator
+  ModelProperty.create(this.id, String? name, int? type,
       {int flags = 0,
       String? indexId,
       this.entity,
@@ -99,9 +100,22 @@ class ModelProperty {
     this.indexId = indexId == null ? null : IdUid.fromString(indexId);
   }
 
+  // used in generated code
+  ModelProperty(
+      {required this.id,
+      required String name,
+      required int type,
+      required int flags,
+      IdUid? indexId,
+      this.relationTarget})
+      : _name = name,
+        _type = type,
+        _flags = flags,
+        _indexId = indexId {}
+
   ModelProperty.fromMap(Map<String, dynamic> data, ModelEntity? entity)
-      : this(IdUid.fromString(data['id'] as String?), data['name'] as String?,
-            data['type'] as int?,
+      : this.create(IdUid.fromString(data['id'] as String?),
+            data['name'] as String?, data['type'] as int?,
             flags: data['flags'] as int? ?? 0,
             indexId: data['indexId'] as String?,
             entity: entity,

--- a/objectbox/lib/src/modelinfo/modelrelation.dart
+++ b/objectbox/lib/src/modelinfo/modelrelation.dart
@@ -39,14 +39,23 @@ class ModelRelation {
     _targetName = value;
   }
 
-  ModelRelation(this.id, String? name, {String? targetId, String? targetName}) {
+  // used in code generator
+  ModelRelation.create(this.id, String? name,
+      {String? targetId, String? targetName}) {
     this.name = name;
     if (targetId != null) this.targetId = IdUid.fromString(targetId);
     if (targetName != null) this.targetName = targetName;
   }
 
+  // used in generated code
+  ModelRelation(
+      {required this.id, required String name, required IdUid targetId})
+      : _name = name,
+        _targetId = targetId;
+
   ModelRelation.fromMap(Map<String, dynamic> data)
-      : this(IdUid.fromString(data['id'] as String?), data['name'] as String?,
+      : this.create(
+            IdUid.fromString(data['id'] as String?), data['name'] as String?,
             targetId: data['targetId'] as String?,
             targetName: data['targetName'] as String?);
 

--- a/objectbox/lib/src/native/box.dart
+++ b/objectbox/lib/src/native/box.dart
@@ -210,7 +210,7 @@ class Box<T> {
 
   /// Returns a builder to create queries for Object matching supplied criteria.
   @pragma('vm:prefer-inline')
-  QueryBuilder<T> query([Condition? qc]) =>
+  QueryBuilder<T> query([Condition<T>? qc]) =>
       QueryBuilder<T>(_store, _entity, qc);
 
   /// Returns the count of all stored Objects in this box.

--- a/objectbox/lib/src/native/observable.dart
+++ b/objectbox/lib/src/native/observable.dart
@@ -87,12 +87,7 @@ extension ObservableStore on Store {
   Stream<Type> subscribeAll() {
     initializeDartAPI();
     final observer = _Observer<Type>();
-
-    // create a map from Entity ID to Entity type (dart class)
-    final entityTypesById = <int, Type>{};
-    InternalStoreAccess.defs(this).bindings.forEach(
-        (Type entity, EntityDefinition entityDef) =>
-            entityTypesById[entityDef.model.id.id] = entity);
+    final entityTypesById = InternalStoreAccess.entityTypeById(this);
 
     observer.init(() {
       // We're listening to a events for all entity types. C-API sends entity ID

--- a/objectbox/lib/src/native/observable.dart
+++ b/objectbox/lib/src/native/observable.dart
@@ -3,7 +3,6 @@ import 'dart:ffi';
 import 'dart:isolate';
 import 'dart:typed_data';
 
-import '../modelinfo/entity_definition.dart';
 import 'bindings/bindings.dart';
 import 'bindings/helpers.dart';
 import 'store.dart';

--- a/objectbox/lib/src/native/query/builder.dart
+++ b/objectbox/lib/src/native/query/builder.dart
@@ -25,10 +25,8 @@ class QueryBuilder<T> extends _QueryBuilder<T> {
 
   /// Configure how the results are ordered.
   /// Pass a combination of [Order] flags.
-  QueryBuilder<T> order(QueryProperty<T> p, {int flags = 0}) {
-    checkObx(C.qb_order(_cBuilder, p._model.id.id, flags));
-    return this;
-  }
+  void order(QueryProperty<T> p, {int flags = 0}) =>
+      checkObx(C.qb_order(_cBuilder, p._model.id.id, flags));
 }
 
 /// Basic/linked query builder only has limited methods: link()
@@ -64,14 +62,6 @@ class _QueryBuilder<T> {
       ObjectBoxNativeError(code, dartStringFromC(C.qb_error_message(_cBuilder)),
               'Query building failed')
           .throwMapped();
-    }
-  }
-
-  @pragma('vm:prefer-inline')
-  void _throwIfOtherEntity(int entityId) {
-    if (entityId != _entity.model.id.id) {
-      throw ArgumentError(
-          'Passed a property of another entity: $entityId instead of ${_entity.model.id.id}');
     }
   }
 

--- a/objectbox/lib/src/native/query/builder.dart
+++ b/objectbox/lib/src/native/query/builder.dart
@@ -25,7 +25,7 @@ class QueryBuilder<T> extends _QueryBuilder<T> {
 
   /// Configure how the results are ordered.
   /// Pass a combination of [Order] flags.
-  void order(QueryProperty<T> p, {int flags = 0}) =>
+  void order<_>(QueryProperty<T, _> p, {int flags = 0}) =>
       checkObx(C.qb_order(_cBuilder, p._model.id.id, flags));
 }
 

--- a/objectbox/lib/src/native/query/builder.dart
+++ b/objectbox/lib/src/native/query/builder.dart
@@ -3,7 +3,7 @@ part of query;
 /// Query builder allows creating reusable queries.
 class QueryBuilder<T> extends _QueryBuilder<T> {
   /// Start creating a query.
-  QueryBuilder(Store store, EntityDefinition<T> entity, Condition? qc)
+  QueryBuilder(Store store, EntityDefinition<T> entity, Condition<T>? qc)
       : super(
             store,
             entity,
@@ -33,7 +33,7 @@ class QueryBuilder<T> extends _QueryBuilder<T> {
 class _QueryBuilder<T> {
   final Store _store;
   final EntityDefinition<T> _entity;
-  final Condition? _queryCondition;
+  final Condition<T>? _queryCondition;
   final Pointer<OBX_query_builder> _cBuilder;
   final _innerQBs = <_QueryBuilder>[];
 
@@ -75,13 +75,13 @@ class _QueryBuilder<T> {
 
   _QueryBuilder<TargetEntityT> link<TargetEntityT>(
           QueryRelationProperty<T, TargetEntityT> rel,
-          [Condition? qc]) =>
+          [Condition<TargetEntityT>? qc]) =>
       _QueryBuilder<TargetEntityT>._link(
           this, qc, C.qb_link_property(_cBuilder, rel._model.id.id));
 
   _QueryBuilder<SourceEntityT> backlink<SourceEntityT>(
           QueryRelationProperty<SourceEntityT, T> rel,
-          [Condition? qc]) =>
+          [Condition<SourceEntityT>? qc]) =>
       _QueryBuilder<SourceEntityT>._link(
           this,
           qc,
@@ -92,13 +92,13 @@ class _QueryBuilder<T> {
 
   _QueryBuilder<TargetEntityT> linkMany<TargetEntityT>(
           QueryRelationMany<T, TargetEntityT> rel,
-          [Condition? qc]) =>
+          [Condition<TargetEntityT>? qc]) =>
       _QueryBuilder<TargetEntityT>._link(
           this, qc, C.qb_link_standalone(_cBuilder, rel._model.id.id));
 
   _QueryBuilder<SourceEntityT> backlinkMany<SourceEntityT>(
           QueryRelationMany<SourceEntityT, T> rel,
-          [Condition? qc]) =>
+          [Condition<SourceEntityT>? qc]) =>
       _QueryBuilder<SourceEntityT>._link(
           this, qc, C.qb_backlink_standalone(_cBuilder, rel._model.id.id));
 }

--- a/objectbox/lib/src/native/query/builder.dart
+++ b/objectbox/lib/src/native/query/builder.dart
@@ -25,9 +25,8 @@ class QueryBuilder<T> extends _QueryBuilder<T> {
 
   /// Configure how the results are ordered.
   /// Pass a combination of [Order] flags.
-  QueryBuilder<T> order(QueryProperty p, {int flags = 0}) {
-    _throwIfOtherEntity(p._entityId);
-    checkObx(C.qb_order(_cBuilder, p._propertyId, flags));
+  QueryBuilder<T> order(QueryProperty<T> p, {int flags = 0}) {
+    checkObx(C.qb_order(_cBuilder, p._model.id.id, flags));
     return this;
   }
 }
@@ -84,35 +83,32 @@ class _QueryBuilder<T> {
     }
   }
 
-  _QueryBuilder<TargetEntityT> link<_, TargetEntityT>(
-      QueryRelationProperty<_, TargetEntityT> rel,
-      [Condition? qc]) {
-    _throwIfOtherEntity(rel._entityId);
-    return _QueryBuilder<TargetEntityT>._link(
-        this, qc, C.qb_link_property(_cBuilder, rel._propertyId));
-  }
+  _QueryBuilder<TargetEntityT> link<TargetEntityT>(
+          QueryRelationProperty<T, TargetEntityT> rel,
+          [Condition? qc]) =>
+      _QueryBuilder<TargetEntityT>._link(
+          this, qc, C.qb_link_property(_cBuilder, rel._model.id.id));
 
-  _QueryBuilder<SourceEntityT> backlink<SourceEntityT, _>(
-      QueryRelationProperty<SourceEntityT, _> rel,
-      [Condition? qc]) {
-    _throwIfOtherEntity(rel._targetEntityId);
-    return _QueryBuilder<SourceEntityT>._link(this, qc,
-        C.qb_backlink_property(_cBuilder, rel._entityId, rel._propertyId));
-  }
+  _QueryBuilder<SourceEntityT> backlink<SourceEntityT>(
+          QueryRelationProperty<SourceEntityT, T> rel,
+          [Condition? qc]) =>
+      _QueryBuilder<SourceEntityT>._link(
+          this,
+          qc,
+          C.qb_backlink_property(
+              _cBuilder,
+              InternalStoreAccess.entityDef<SourceEntityT>(_store).model.id.id,
+              rel._model.id.id));
 
-  _QueryBuilder<TargetEntityT> linkMany<_, TargetEntityT>(
-      QueryRelationMany<_, TargetEntityT> rel,
-      [Condition? qc]) {
-    _throwIfOtherEntity(rel._entityId);
-    return _QueryBuilder<TargetEntityT>._link(
-        this, qc, C.qb_link_standalone(_cBuilder, rel._relationId));
-  }
+  _QueryBuilder<TargetEntityT> linkMany<TargetEntityT>(
+          QueryRelationMany<T, TargetEntityT> rel,
+          [Condition? qc]) =>
+      _QueryBuilder<TargetEntityT>._link(
+          this, qc, C.qb_link_standalone(_cBuilder, rel._model.id.id));
 
-  _QueryBuilder<SourceEntityT> backlinkMany<SourceEntityT, _>(
-      QueryRelationMany<SourceEntityT, _> rel,
-      [Condition? qc]) {
-    _throwIfOtherEntity(rel._targetEntityId);
-    return _QueryBuilder<SourceEntityT>._link(
-        this, qc, C.qb_backlink_standalone(_cBuilder, rel._relationId));
-  }
+  _QueryBuilder<SourceEntityT> backlinkMany<SourceEntityT>(
+          QueryRelationMany<SourceEntityT, T> rel,
+          [Condition? qc]) =>
+      _QueryBuilder<SourceEntityT>._link(
+          this, qc, C.qb_backlink_standalone(_cBuilder, rel._model.id.id));
 }

--- a/objectbox/lib/src/native/query/property.dart
+++ b/objectbox/lib/src/native/query/property.dart
@@ -6,9 +6,10 @@ abstract class PropertyQuery<T> {
   final int _type;
   bool _distinct = false;
 
-  PropertyQuery._(Pointer<OBX_query> cQuery, int propertyId, this._type)
-      : _cProp =
-            checkObxPtr(C.query_prop(cQuery, propertyId), 'property query');
+  PropertyQuery._(Pointer<OBX_query> cQuery, ModelProperty property)
+      : _type = property.type,
+        _cProp =
+            checkObxPtr(C.query_prop(cQuery, property.id.id), 'property query');
 
   /// Returns values of this property matching the query.
   ///
@@ -75,8 +76,8 @@ mixin _CommonNumeric<T> on PropertyQuery<T> {
 
 /// "Property query" for an integer field. Created by [Query.property()].
 class IntegerPropertyQuery extends PropertyQuery<int> with _CommonNumeric {
-  IntegerPropertyQuery._(Pointer<OBX_query> query, int propertyId, int obxType)
-      : super._(query, propertyId, obxType);
+  IntegerPropertyQuery._(Pointer<OBX_query> query, ModelProperty property)
+      : super._(query, property);
 
   int _op(
       int Function(Pointer<OBX_query_prop>, Pointer<Int64>, Pointer<Int64>)
@@ -153,8 +154,8 @@ class IntegerPropertyQuery extends PropertyQuery<int> with _CommonNumeric {
 
 /// "Property query" for a double field. Created by [Query.property()].
 class DoublePropertyQuery extends PropertyQuery<double> with _CommonNumeric {
-  DoublePropertyQuery._(Pointer<OBX_query> query, int propertyId, int obxType)
-      : super._(query, propertyId, obxType);
+  DoublePropertyQuery._(Pointer<OBX_query> query, ModelProperty property)
+      : super._(query, property);
 
   double _op(
       int Function(Pointer<OBX_query_prop>, Pointer<Double>, Pointer<Int64>)
@@ -212,9 +213,8 @@ class StringPropertyQuery extends PropertyQuery<String> {
   bool _caseSensitive;
 
   StringPropertyQuery._(
-      Store store, Pointer<OBX_query> query, int propertyId, int obxType)
-      : _caseSensitive = InternalStoreAccess.queryCS(store),
-        super._(query, propertyId, obxType);
+      Pointer<OBX_query> query, ModelProperty property, this._caseSensitive)
+      : super._(query, property);
 
   /// Use case-sensitive comparison when querying [distinct] values.
   /// E.g. returning "foo","Foo","FOO" instead of just "foo".

--- a/objectbox/lib/src/native/query/property.dart
+++ b/objectbox/lib/src/native/query/property.dart
@@ -1,39 +1,21 @@
 part of query;
 
 /// Property query base.
-abstract class PropertyQuery<T> {
+class PropertyQuery<T> {
   final Pointer<OBX_query_prop> _cProp;
   final int _type;
   bool _distinct = false;
+  bool _caseSensitive = false;
 
   PropertyQuery._(Pointer<OBX_query> cQuery, ModelProperty property)
       : _type = property.type,
         _cProp =
             checkObxPtr(C.query_prop(cQuery, property.id.id), 'property query');
 
-  /// Returns values of this property matching the query.
-  ///
-  /// Results are in no particular order. Excludes null values.
-  /// Set [replaceNullWith] to return null values as that value.
-  List<T> find({T? replaceNullWith});
-
   /// Close the property query, freeing its resources
   void close() => checkObx(C.query_prop_close(_cProp));
 
-  /// Get the status of "distinct-values" configuration.
-  bool get distinct => _distinct;
-
-  /// Set to only return distinct values.
-  ///
-  /// E.g. [1,2,3] instead of [1,1,2,3,3,3].
-  /// Strings default to case-insensitive comparison.
-  set distinct(bool d) {
-    _distinct = d;
-    checkObx(C.query_prop_distinct(_cProp, d));
-  }
-
-  /// Returns the count of non-null values.
-  int count() {
+  int _count() {
     final ptr = malloc<Uint64>();
     try {
       checkObx(C.query_prop_count(_cProp, ptr));
@@ -58,12 +40,8 @@ abstract class PropertyQuery<T> {
       if (cItems != nullptr) listFreeFn(cItems);
     }
   }
-}
 
-/// shared implementation, hence mixin
-mixin _CommonNumeric<T> on PropertyQuery<T> {
-  /// Average value of the property over all objects matching the query.
-  double average() {
+  double _average() {
     final ptr = malloc<Double>();
     try {
       checkObx(C.query_prop_avg(_cProp, ptr, nullptr));
@@ -75,10 +53,7 @@ mixin _CommonNumeric<T> on PropertyQuery<T> {
 }
 
 /// "Property query" for an integer field. Created by [Query.property()].
-class IntegerPropertyQuery extends PropertyQuery<int> with _CommonNumeric {
-  IntegerPropertyQuery._(Pointer<OBX_query> query, ModelProperty property)
-      : super._(query, property);
-
+extension IntegerPropertyQuery on PropertyQuery<int> {
   int _op(
       int Function(Pointer<OBX_query_prop>, Pointer<Int64>, Pointer<Int64>)
           fn) {
@@ -91,6 +66,24 @@ class IntegerPropertyQuery extends PropertyQuery<int> with _CommonNumeric {
     }
   }
 
+  /// Average value of the property over all objects matching the query.
+  double average() => _average();
+
+  /// Returns the count of non-null values.
+  int count() => _count();
+
+  /// Get the status of "distinct-values" configuration.
+  bool get distinct => _distinct;
+
+  /// Set to only return distinct values.
+  ///
+  /// E.g. [1,2,3] instead of [1,1,2,3,3,3].
+  /// Strings default to case-insensitive comparison.
+  set distinct(bool d) {
+    _distinct = d;
+    checkObx(C.query_prop_distinct(_cProp, d));
+  }
+
   /// Minimum value of the property over all objects matching the query.
   int min() => _op(C.query_prop_min_int);
 
@@ -100,7 +93,10 @@ class IntegerPropertyQuery extends PropertyQuery<int> with _CommonNumeric {
   /// Sum of all property values over objects matching the query.
   int sum() => _op(C.query_prop_sum_int);
 
-  @override
+  /// Returns values of this property matching the query.
+  ///
+  /// Results are in no particular order. Excludes null values unless you
+  /// specify [replaceNullWith].
   List<int> find({int? replaceNullWith}) {
     switch (_type) {
       case OBXPropertyType.Bool:
@@ -153,10 +149,7 @@ class IntegerPropertyQuery extends PropertyQuery<int> with _CommonNumeric {
 }
 
 /// "Property query" for a double field. Created by [Query.property()].
-class DoublePropertyQuery extends PropertyQuery<double> with _CommonNumeric {
-  DoublePropertyQuery._(Pointer<OBX_query> query, ModelProperty property)
-      : super._(query, property);
-
+extension DoublePropertyQuery on PropertyQuery<double> {
   double _op(
       int Function(Pointer<OBX_query_prop>, Pointer<Double>, Pointer<Int64>)
           fn) {
@@ -169,6 +162,24 @@ class DoublePropertyQuery extends PropertyQuery<double> with _CommonNumeric {
     }
   }
 
+  /// Average value of the property over all objects matching the query.
+  double average() => _average();
+
+  /// Returns the count of non-null values.
+  int count() => _count();
+
+  /// Get the status of "distinct-values" configuration.
+  bool get distinct => _distinct;
+
+  /// Set to only return distinct values.
+  ///
+  /// E.g. [1,2,3] instead of [1,1,2,3,3,3].
+  /// Strings default to case-insensitive comparison.
+  set distinct(bool d) {
+    _distinct = d;
+    checkObx(C.query_prop_distinct(_cProp, d));
+  }
+
   /// Minimum value of the property over all objects matching the query.
   double min() => _op(C.query_prop_min);
 
@@ -178,7 +189,10 @@ class DoublePropertyQuery extends PropertyQuery<double> with _CommonNumeric {
   /// Sum of all property values over objects matching the query.
   double sum() => _op(C.query_prop_sum);
 
-  @override
+  /// Returns values of this property matching the query.
+  ///
+  /// Results are in no particular order. Excludes null values unless you
+  /// specify [replaceNullWith].
   List<double> find({double? replaceNullWith}) {
     switch (_type) {
       case OBXPropertyType.Float:
@@ -209,13 +223,7 @@ class DoublePropertyQuery extends PropertyQuery<double> with _CommonNumeric {
 }
 
 /// "Property query" for a string field. Created by [Query.property()].
-class StringPropertyQuery extends PropertyQuery<String> {
-  bool _caseSensitive;
-
-  StringPropertyQuery._(
-      Pointer<OBX_query> query, ModelProperty property, this._caseSensitive)
-      : super._(query, property);
-
+extension StringPropertyQuery on PropertyQuery<String> {
   /// Use case-sensitive comparison when querying [distinct] values.
   /// E.g. returning "foo","Foo","FOO" instead of just "foo".
   set caseSensitive(bool caseSensitive) {
@@ -226,22 +234,30 @@ class StringPropertyQuery extends PropertyQuery<String> {
   /// Get status of the case-sensitive configuration.
   bool get caseSensitive => _caseSensitive;
 
-  @override
+  /// Get the status of "distinct-values" configuration.
+  bool get distinct => _distinct;
+
+  /// Set to only return distinct values.
+  ///
+  /// E.g. [foo, bar] instead of [foo, bar, bar, bar, foo].
+  /// Strings default to case-insensitive comparison.
   set distinct(bool d) {
     _distinct = d;
     checkObx(C.query_prop_distinct_case(_cProp, d, _caseSensitive));
   }
 
   /// Returns the count of non-null values.
-  @override
   int count() {
     // native c-api currently doesn't respect case-sensitive with distinct
     // TODO Remove once this is fixed in all platforms (c-api ^0.13.1)
     if (_distinct && !_caseSensitive) return find().length;
-    return super.count();
+    return _count();
   }
 
-  @override
+  /// Returns values of this property matching the query.
+  ///
+  /// Results are in no particular order. Excludes null values unless you
+  /// specify [replaceNullWith].
   List<String> find({String? replaceNullWith}) {
     final cDefault = replaceNullWith == null
         ? null

--- a/objectbox/lib/src/native/query/query.dart
+++ b/objectbox/lib/src/native/query/query.dart
@@ -611,12 +611,8 @@ class Query<T> {
   /// this offset. Example use case: use together with limit to get a slice of
   /// the whole result, e.g. for "result paging".
   ///
-  /// Call with offset=0 to reset to the default behavior,
-  /// i.e. starting from the first element.
-  Query<T> offset(int offset) {
-    checkObx(C.query_offset(_cQuery, offset));
-    return this;
-  }
+  /// Set offset=0 to reset to the default - starting from the first element.
+  set offset(int offset) => checkObx(C.query_offset(_cQuery, offset));
 
   /// Configure a [limit] for this query.
   ///
@@ -624,12 +620,8 @@ class Query<T> {
   /// of Objects. Example use case: use together with offset to get a slice of
   /// the whole result, e.g. for "result paging".
   ///
-  /// Call with limit=0 to reset to the default behavior -
-  /// zero limit means no limit applied.
-  Query<T> limit(int limit) {
-    checkObx(C.query_limit(_cQuery, limit));
-    return this;
-  }
+  /// Set limit=0 to reset to the default behavior - no limit applied.
+  set limit(int limit) => checkObx(C.query_limit(_cQuery, limit));
 
   /// Returns the number of matching Objects.
   int count() {

--- a/objectbox/lib/src/native/query/query.dart
+++ b/objectbox/lib/src/native/query/query.dart
@@ -48,149 +48,163 @@ class QueryProperty<EntityT, DartType> {
 
   QueryProperty(this._model);
 
-  Condition isNull() => _NullCondition(_ConditionOp.isNull, this);
+  Condition<EntityT> isNull() =>
+      _NullCondition<EntityT, DartType>(_ConditionOp.isNull, this);
 
-  Condition notNull() => _NullCondition(_ConditionOp.notNull, this);
+  Condition<EntityT> notNull() =>
+      _NullCondition<EntityT, DartType>(_ConditionOp.notNull, this);
 }
 
 class QueryStringProperty<EntityT> extends QueryProperty<EntityT, String> {
   QueryStringProperty(ModelProperty model) : super(model);
 
-  Condition _op(String p, _ConditionOp cop, {bool? caseSensitive}) =>
-      _StringCondition(cop, this, p, null, caseSensitive: caseSensitive);
+  Condition<EntityT> _op(String p, _ConditionOp cop, {bool? caseSensitive}) =>
+      _StringCondition<EntityT, String>(cop, this, p, null,
+          caseSensitive: caseSensitive);
 
-  Condition _opList(List<String> list, _ConditionOp cop,
+  Condition<EntityT> _opList(List<String> list, _ConditionOp cop,
           {bool? caseSensitive}) =>
-      _StringListCondition(cop, this, list, caseSensitive: caseSensitive);
+      _StringListCondition<EntityT>(cop, this, list,
+          caseSensitive: caseSensitive);
 
-  Condition equals(String p, {bool? caseSensitive}) =>
+  Condition<EntityT> equals(String p, {bool? caseSensitive}) =>
       _op(p, _ConditionOp.eq, caseSensitive: caseSensitive);
 
-  Condition notEquals(String p, {bool? caseSensitive}) =>
+  Condition<EntityT> notEquals(String p, {bool? caseSensitive}) =>
       _op(p, _ConditionOp.notEq, caseSensitive: caseSensitive);
 
-  Condition endsWith(String p, {bool? caseSensitive}) =>
+  Condition<EntityT> endsWith(String p, {bool? caseSensitive}) =>
       _op(p, _ConditionOp.endsWith, caseSensitive: caseSensitive);
 
-  Condition startsWith(String p, {bool? caseSensitive}) =>
+  Condition<EntityT> startsWith(String p, {bool? caseSensitive}) =>
       _op(p, _ConditionOp.startsWith, caseSensitive: caseSensitive);
 
-  Condition contains(String p, {bool? caseSensitive}) =>
+  Condition<EntityT> contains(String p, {bool? caseSensitive}) =>
       _op(p, _ConditionOp.contains, caseSensitive: caseSensitive);
 
-  Condition inside(List<String> list, {bool? caseSensitive}) =>
+  Condition<EntityT> inside(List<String> list, {bool? caseSensitive}) =>
       _opList(list, _ConditionOp.inside, caseSensitive: caseSensitive);
 
-  Condition notIn(List<String> list, {bool? caseSensitive}) =>
+  Condition<EntityT> notIn(List<String> list, {bool? caseSensitive}) =>
       _opList(list, _ConditionOp.notIn, caseSensitive: caseSensitive);
 
-  Condition greaterThan(String p, {bool? caseSensitive}) =>
+  Condition<EntityT> greaterThan(String p, {bool? caseSensitive}) =>
       _op(p, _ConditionOp.gt, caseSensitive: caseSensitive);
 
-  Condition greaterOrEqual(String p, {bool? caseSensitive}) =>
+  Condition<EntityT> greaterOrEqual(String p, {bool? caseSensitive}) =>
       _op(p, _ConditionOp.greaterOrEq, caseSensitive: caseSensitive);
 
-  Condition lessThan(String p, {bool? caseSensitive}) =>
+  Condition<EntityT> lessThan(String p, {bool? caseSensitive}) =>
       _op(p, _ConditionOp.lt, caseSensitive: caseSensitive);
 
-  Condition lessOrEqual(String p, {bool? caseSensitive}) =>
+  Condition<EntityT> lessOrEqual(String p, {bool? caseSensitive}) =>
       _op(p, _ConditionOp.lessOrEq, caseSensitive: caseSensitive);
 }
 
-class QueryByteVectorProperty<EntityT> extends QueryProperty<EntityT, Never> {
+class QueryByteVectorProperty<EntityT>
+    extends QueryProperty<EntityT, Uint8List> {
   QueryByteVectorProperty(ModelProperty model) : super(model);
 
-  Condition _op(List<int> val, _ConditionOp cop) =>
-      _ByteVectorCondition(cop, this, Uint8List.fromList(val));
+  Condition<EntityT> _op(List<int> val, _ConditionOp cop) =>
+      _ByteVectorCondition<EntityT>(cop, this, Uint8List.fromList(val));
 
-  Condition equals(List<int> val) => _op(val, _ConditionOp.eq);
+  Condition<EntityT> equals(List<int> val) => _op(val, _ConditionOp.eq);
 
-  Condition greaterThan(List<int> val) => _op(val, _ConditionOp.gt);
+  Condition<EntityT> greaterThan(List<int> val) => _op(val, _ConditionOp.gt);
 
-  Condition greaterOrEqual(List<int> val) => _op(val, _ConditionOp.greaterOrEq);
+  Condition<EntityT> greaterOrEqual(List<int> val) =>
+      _op(val, _ConditionOp.greaterOrEq);
 
-  Condition lessThan(List<int> val) => _op(val, _ConditionOp.lt);
+  Condition<EntityT> lessThan(List<int> val) => _op(val, _ConditionOp.lt);
 
-  Condition lessOrEqual(List<int> val) => _op(val, _ConditionOp.lessOrEq);
+  Condition<EntityT> lessOrEqual(List<int> val) =>
+      _op(val, _ConditionOp.lessOrEq);
 }
 
 class QueryIntegerProperty<EntityT> extends QueryProperty<EntityT, int> {
   QueryIntegerProperty(ModelProperty model) : super(model);
 
-  Condition _op(int p, _ConditionOp cop) => _IntegerCondition(cop, this, p, 0);
+  Condition<EntityT> _op(int p, _ConditionOp cop) =>
+      _IntegerCondition<EntityT, int>(cop, this, p, 0);
 
-  Condition _opList(List<int> list, _ConditionOp cop) =>
-      _IntegerListCondition(cop, this, list);
+  Condition<EntityT> _opList(List<int> list, _ConditionOp cop) =>
+      _IntegerListCondition<EntityT>(cop, this, list);
 
-  Condition equals(int p) => _op(p, _ConditionOp.eq);
+  Condition<EntityT> equals(int p) => _op(p, _ConditionOp.eq);
 
-  Condition notEquals(int p) => _op(p, _ConditionOp.notEq);
+  Condition<EntityT> notEquals(int p) => _op(p, _ConditionOp.notEq);
 
-  Condition greaterThan(int p) => _op(p, _ConditionOp.gt);
+  Condition<EntityT> greaterThan(int p) => _op(p, _ConditionOp.gt);
 
-  Condition greaterOrEqual(int p) => _op(p, _ConditionOp.greaterOrEq);
+  Condition<EntityT> greaterOrEqual(int p) => _op(p, _ConditionOp.greaterOrEq);
 
-  Condition lessThan(int p) => _op(p, _ConditionOp.lt);
+  Condition<EntityT> lessThan(int p) => _op(p, _ConditionOp.lt);
 
-  Condition lessOrEqual(int p) => _op(p, _ConditionOp.lessOrEq);
+  Condition<EntityT> lessOrEqual(int p) => _op(p, _ConditionOp.lessOrEq);
 
-  Condition operator <(int p) => lessThan(p);
+  Condition<EntityT> operator <(int p) => lessThan(p);
 
-  Condition operator >(int p) => greaterThan(p);
+  Condition<EntityT> operator >(int p) => greaterThan(p);
 
-  Condition inside(List<int> list) => _opList(list, _ConditionOp.inside);
+  Condition<EntityT> inside(List<int> list) =>
+      _opList(list, _ConditionOp.inside);
 
-  Condition notInList(List<int> list) => _opList(list, _ConditionOp.notIn);
+  Condition<EntityT> notInList(List<int> list) =>
+      _opList(list, _ConditionOp.notIn);
 
-  Condition notIn(List<int> list) => notInList(list);
+  Condition<EntityT> notIn(List<int> list) => notInList(list);
 }
 
 class QueryDoubleProperty<EntityT> extends QueryProperty<EntityT, double> {
   QueryDoubleProperty(ModelProperty model) : super(model);
 
-  Condition _op(_ConditionOp op, double p1, double? p2) =>
-      _DoubleCondition(op, this, p1, p2);
+  Condition<EntityT> _op(_ConditionOp op, double p1, double? p2) =>
+      _DoubleCondition<EntityT>(op, this, p1, p2);
 
-  Condition between(double p1, double p2) => _op(_ConditionOp.between, p1, p2);
+  Condition<EntityT> between(double p1, double p2) =>
+      _op(_ConditionOp.between, p1, p2);
 
   // NOTE: objectbox-c doesn't support double/float equality (because it's a
   // rather peculiar thing). Therefore, we're currently not providing this in
   // Dart either, not even with some `between()` workarounds.
-  // Condition equals(double p) {
+  // Condition<EntityT> equals(double p) {
   //    _op(_ConditionOp.eq, p);
   // }
 
-  Condition greaterThan(double p) => _op(_ConditionOp.gt, p, null);
+  Condition<EntityT> greaterThan(double p) => _op(_ConditionOp.gt, p, null);
 
-  Condition greaterOrEqual(double p) => _op(_ConditionOp.greaterOrEq, p, null);
+  Condition<EntityT> greaterOrEqual(double p) =>
+      _op(_ConditionOp.greaterOrEq, p, null);
 
-  Condition lessThan(double p) => _op(_ConditionOp.lt, p, null);
+  Condition<EntityT> lessThan(double p) => _op(_ConditionOp.lt, p, null);
 
-  Condition lessOrEqual(double p) => _op(_ConditionOp.lessOrEq, p, null);
+  Condition<EntityT> lessOrEqual(double p) =>
+      _op(_ConditionOp.lessOrEq, p, null);
 
-  Condition operator <(double p) => lessThan(p);
+  Condition<EntityT> operator <(double p) => lessThan(p);
 
-  Condition operator >(double p) => greaterThan(p);
+  Condition<EntityT> operator >(double p) => greaterThan(p);
 }
 
 class QueryBooleanProperty<EntityT> extends QueryProperty<EntityT, bool> {
   QueryBooleanProperty(ModelProperty model) : super(model);
 
   // ignore: avoid_positional_boolean_parameters
-  Condition equals(bool p) =>
-      _IntegerCondition(_ConditionOp.eq, this, (p ? 1 : 0));
+  Condition<EntityT> equals(bool p) =>
+      _IntegerCondition<EntityT, bool>(_ConditionOp.eq, this, (p ? 1 : 0));
 
   // ignore: avoid_positional_boolean_parameters
-  Condition notEquals(bool p) =>
-      _IntegerCondition(_ConditionOp.notEq, this, (p ? 1 : 0));
+  Condition<EntityT> notEquals(bool p) =>
+      _IntegerCondition<EntityT, bool>(_ConditionOp.notEq, this, (p ? 1 : 0));
 }
 
 class QueryStringVectorProperty<EntityT>
     extends QueryProperty<EntityT, List<String>> {
   QueryStringVectorProperty(ModelProperty model) : super(model);
 
-  Condition contains(String p, {bool? caseSensitive}) =>
-      _StringCondition(_ConditionOp.contains, this, p, null,
+  Condition<EntityT> contains(String p, {bool? caseSensitive}) =>
+      _StringCondition<EntityT, List<String>>(
+          _ConditionOp.contains, this, p, null,
           caseSensitive: caseSensitive);
 }
 
@@ -223,50 +237,45 @@ enum _ConditionOp {
 }
 
 /// A [Query] condition base class.
-abstract class Condition {
+abstract class Condition<EntityT> {
   // using & because && is not overridable
-  Condition operator &(Condition rh) => and(rh);
+  Condition<EntityT> operator &(Condition<EntityT> rh) => and(rh);
 
-  Condition and(Condition rh) {
+  Condition<EntityT> and(Condition<EntityT> rh) {
     if (this is _ConditionGroupAll) {
       // no need for brackets
-      return _ConditionGroupAll(
-          [...(this as _ConditionGroupAll)._conditions, rh]);
+      return _ConditionGroupAll<EntityT>(
+          [...(this as _ConditionGroupAll<EntityT>)._conditions, rh]);
     }
-    return _ConditionGroupAll([this, rh]);
+    return _ConditionGroupAll<EntityT>([this, rh]);
   }
 
-  Condition andAll(List<Condition> rh) => _ConditionGroupAll([this, ...rh]);
+  Condition<EntityT> andAll(List<Condition<EntityT>> rh) =>
+      _ConditionGroupAll<EntityT>([this, ...rh]);
 
   // using | because || is not overridable
-  Condition operator |(Condition rh) => or(rh);
+  Condition<EntityT> operator |(Condition<EntityT> rh) => or(rh);
 
-  Condition or(Condition rh) {
+  Condition<EntityT> or(Condition<EntityT> rh) {
     if (this is _ConditionGroupAny) {
       // no need for brackets
-      return _ConditionGroupAny(
-          [...(this as _ConditionGroupAny)._conditions, rh]);
+      return _ConditionGroupAny<EntityT>(
+          [...(this as _ConditionGroupAny<EntityT>)._conditions, rh]);
     }
-    return _ConditionGroupAny([this, rh]);
+    return _ConditionGroupAny<EntityT>([this, rh]);
   }
 
-  Condition orAny(List<Condition> rh) => _ConditionGroupAny([this, ...rh]);
+  Condition<EntityT> orAny(List<Condition<EntityT>> rh) =>
+      _ConditionGroupAny<EntityT>([this, ...rh]);
 
   int _apply(_QueryBuilder builder, {required bool isRoot});
 }
 
-abstract class _PropertyCondition<DartType> extends Condition {
-  final QueryProperty _property;
-  final DartType _value;
-  final DartType? _value2;
-
+class _NullCondition<EntityT, DartType> extends Condition<EntityT> {
+  final QueryProperty<EntityT, DartType> _property;
   final _ConditionOp _op;
 
-  _PropertyCondition(this._op, this._property, this._value, [this._value2]);
-}
-
-class _NullCondition extends _PropertyCondition<Null> {
-  _NullCondition(_ConditionOp op, QueryProperty prop) : super(op, prop, null);
+  _NullCondition(this._op, this._property);
 
   @override
   int _apply(_QueryBuilder builder, {required bool isRoot}) {
@@ -281,11 +290,26 @@ class _NullCondition extends _PropertyCondition<Null> {
   }
 }
 
-class _StringCondition extends _PropertyCondition<String> {
+abstract class _PropertyCondition<EntityT, PropertyDartType, ValueDartType>
+    extends Condition<EntityT> {
+  final QueryProperty<EntityT, PropertyDartType> _property;
+  final ValueDartType _value;
+  final ValueDartType? _value2;
+
+  final _ConditionOp _op;
+
+  _PropertyCondition(this._op, this._property, this._value, [this._value2]);
+}
+
+class _StringCondition<EntityT, PropertyDartType>
+    extends _PropertyCondition<EntityT, PropertyDartType, String> {
   bool? caseSensitive;
 
   _StringCondition(
-      _ConditionOp op, QueryProperty prop, String value, String? value2,
+      _ConditionOp op,
+      QueryProperty<EntityT, PropertyDartType> prop,
+      String value,
+      String? value2,
       {this.caseSensitive})
       : super(op, prop, value, value2);
 
@@ -330,10 +354,12 @@ class _StringCondition extends _PropertyCondition<String> {
   }
 }
 
-class _StringListCondition extends _PropertyCondition<List<String>> {
+class _StringListCondition<EntityT>
+    extends _PropertyCondition<EntityT, String, List<String>> {
   bool? caseSensitive;
 
-  _StringListCondition(_ConditionOp op, QueryProperty prop, List<String> value,
+  _StringListCondition(
+      _ConditionOp op, QueryProperty<EntityT, String> prop, List<String> value,
       {this.caseSensitive})
       : super(op, prop, value);
 
@@ -370,8 +396,10 @@ class _StringListCondition extends _PropertyCondition<List<String>> {
   }
 }
 
-class _IntegerCondition extends _PropertyCondition<int> {
-  _IntegerCondition(_ConditionOp op, QueryProperty prop, int value,
+class _IntegerCondition<EntityT, PropertyDartType>
+    extends _PropertyCondition<EntityT, PropertyDartType, int> {
+  _IntegerCondition(
+      _ConditionOp op, QueryProperty<EntityT, PropertyDartType> prop, int value,
       [int? value2])
       : super(op, prop, value, value2);
 
@@ -403,8 +431,10 @@ class _IntegerCondition extends _PropertyCondition<int> {
   }
 }
 
-class _IntegerListCondition extends _PropertyCondition<List<int>> {
-  _IntegerListCondition(_ConditionOp op, QueryProperty prop, List<int> value)
+class _IntegerListCondition<EntityT>
+    extends _PropertyCondition<EntityT, int, List<int>> {
+  _IntegerListCondition(
+      _ConditionOp op, QueryProperty<EntityT, int> prop, List<int> value)
       : super(op, prop, value);
 
   int _opList<T extends NativeType>(
@@ -464,9 +494,10 @@ class _IntegerListCondition extends _PropertyCondition<List<int>> {
   }
 }
 
-class _DoubleCondition extends _PropertyCondition<double> {
-  _DoubleCondition(
-      _ConditionOp op, QueryProperty prop, double value, double? value2)
+class _DoubleCondition<EntityT>
+    extends _PropertyCondition<EntityT, double, double> {
+  _DoubleCondition(_ConditionOp op, QueryProperty<EntityT, double> prop,
+      double value, double? value2)
       : super(op, prop, value, value2) {
     assert(op != _ConditionOp.eq,
         'Equality operator is not supported on floating point numbers - use between() instead.');
@@ -496,8 +527,10 @@ class _DoubleCondition extends _PropertyCondition<double> {
   }
 }
 
-class _ByteVectorCondition extends _PropertyCondition<Uint8List> {
-  _ByteVectorCondition(_ConditionOp op, QueryProperty prop, Uint8List value)
+class _ByteVectorCondition<EntityT>
+    extends _PropertyCondition<EntityT, Uint8List, Uint8List> {
+  _ByteVectorCondition(
+      _ConditionOp op, QueryProperty<EntityT, Uint8List> prop, Uint8List value)
       : super(op, prop, value);
 
   int _op1(
@@ -528,8 +561,8 @@ class _ByteVectorCondition extends _PropertyCondition<Uint8List> {
   }
 }
 
-class _ConditionGroup extends Condition {
-  final List<Condition> _conditions;
+class _ConditionGroup<EntityT> extends Condition<EntityT> {
+  final List<Condition<EntityT>> _conditions;
   final int Function(Pointer<OBX_query_builder>, Pointer<Int32>, int) _func;
 
   _ConditionGroup(this._conditions, this._func);
@@ -569,12 +602,14 @@ class _ConditionGroup extends Condition {
   }
 }
 
-class _ConditionGroupAny extends _ConditionGroup {
-  _ConditionGroupAny(List<Condition> conditions) : super(conditions, C.qb_any);
+class _ConditionGroupAny<EntityT> extends _ConditionGroup<EntityT> {
+  _ConditionGroupAny(List<Condition<EntityT>> conditions)
+      : super(conditions, C.qb_any);
 }
 
-class _ConditionGroupAll extends _ConditionGroup {
-  _ConditionGroupAll(List<Condition> conditions) : super(conditions, C.qb_all);
+class _ConditionGroupAll<EntityT> extends _ConditionGroup<EntityT> {
+  _ConditionGroupAll(List<Condition<EntityT>> conditions)
+      : super(conditions, C.qb_all);
 }
 
 /// A repeatable Query returning the latest matching Objects.

--- a/objectbox/lib/src/native/store.dart
+++ b/objectbox/lib/src/native/store.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:ffi';
 import 'dart:io';
 import 'dart:typed_data';
@@ -19,7 +20,7 @@ import 'sync.dart';
 /// getting and putting.
 class Store {
   late final Pointer<OBX_store> _cStore;
-  final _boxes = <Type, Box>{};
+  final _boxes = HashMap<Type, Box>();
   final ModelDefinition _defs;
   bool _closed = false;
 
@@ -247,6 +248,14 @@ class InternalStoreAccess {
 
   /// Access model definitions
   static ModelDefinition defs(Store store) => store._defs;
+
+  // create a map from Entity ID to Entity type (dart class)
+  static Map<int, Type> entityTypeById(Store store) {
+    final result = HashMap<int, Type>();
+    store._defs.bindings.forEach((Type entity, EntityDefinition entityDef) =>
+        result[entityDef.model.id.id] = entity);
+    return result;
+  }
 
   /// Adds a listener to the [store.close()] event.
   static void addCloseListener(

--- a/objectbox/lib/src/native/store.dart
+++ b/objectbox/lib/src/native/store.dart
@@ -249,7 +249,7 @@ class InternalStoreAccess {
   /// Access model definitions
   static ModelDefinition defs(Store store) => store._defs;
 
-  // create a map from Entity ID to Entity type (dart class)
+  /// Create a map from Entity ID to Entity type (dart class).
   static Map<int, Type> entityTypeById(Store store) {
     final result = HashMap<int, Type>();
     store._defs.bindings.forEach((Type entity, EntityDefinition entityDef) =>

--- a/objectbox/lib/src/native/sync.dart
+++ b/objectbox/lib/src/native/sync.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:collection';
 import 'dart:convert' show utf8;
 import 'dart:ffi';
 import 'dart:isolate';

--- a/objectbox/lib/src/native/sync.dart
+++ b/objectbox/lib/src/native/sync.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert' show utf8;
 import 'dart:ffi';
 import 'dart:isolate';
@@ -7,7 +8,6 @@ import 'dart:typed_data';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 
-import '../modelinfo/entity_definition.dart';
 import '../util.dart';
 import 'bindings/bindings.dart';
 import 'bindings/helpers.dart';
@@ -368,11 +368,7 @@ class SyncClient {
       // This stream combines events from two C listeners: connect & disconnect.
       _changeEvents = _SyncListenerGroup<List<SyncChange>>('sync-change');
 
-      // create a map from Entity ID to Entity type (dart class)
-      final entityTypesById = <int, Type>{};
-      InternalStoreAccess.defs(_store).bindings.forEach(
-          (Type entity, EntityDefinition entityDef) =>
-              entityTypesById[entityDef.model.id.id] = entity);
+      final entityTypesById = InternalStoreAccess.entityTypeById(_store);
 
       _changeEvents!.add(_SyncListenerConfig(
           (int nativePort) => C.dartc_sync_listener_change(_ptr, nativePort),

--- a/objectbox/lib/src/native/transaction.dart
+++ b/objectbox/lib/src/native/transaction.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:ffi';
 
 import 'package:meta/meta.dart';
@@ -23,7 +24,7 @@ class Transaction {
   // We have two ways of keeping cursors because we usually need just one.
   // The variable is faster then the map initialization & access.
   CursorHelper? _firstCursor;
-  Map<int, CursorHelper>? _cursors;
+  HashMap<int, CursorHelper>? _cursors;
 
   Pointer<OBX_txn> get ptr => _cTxn;
 
@@ -86,7 +87,7 @@ class Transaction {
     } else if (_firstCursor!.entity == entity) {
       return _firstCursor as CursorHelper<T>;
     }
-    _cursors ??= <int, CursorHelper>{};
+    _cursors ??= HashMap<int, CursorHelper>();
     final entityId = entity.model.id.id;
     final cursors = _cursors!;
     if (!cursors.containsKey(entityId)) {

--- a/objectbox/lib/src/util.dart
+++ b/objectbox/lib/src/util.dart
@@ -1,7 +1,9 @@
+import 'dart:collection';
+
 import 'store.dart';
 import 'sync.dart';
 
 // ignore_for_file: public_member_api_docs
 
 /// Global internal storage of sync clients - one client per store.
-final Map<Store, SyncClient> syncClientsStorage = {};
+final syncClientsStorage = HashMap<Store, SyncClient>();

--- a/objectbox/test/basics_test.dart
+++ b/objectbox/test/basics_test.dart
@@ -28,7 +28,7 @@ void main() {
   });
 
   test('model UID generation', () {
-    final model = ModelInfo();
+    final model = ModelInfo.empty();
     final uid1 = model.generateUid();
     final uid2 = model.generateUid();
     expect(uid1, isNot(equals(uid2)));

--- a/objectbox/test/query_property_test.dart
+++ b/objectbox/test/query_property_test.dart
@@ -107,20 +107,20 @@ void main() {
 
     final query = box.query(tLong < 2).build();
 
-    tSignedInts.forEach((i) {
-      final qp = query.property(i);
-      expect(qp is IntegerPropertyQuery, true);
+    tSignedInts.forEach((prop) {
+      final qp = query.property(prop);
+      expect(qp is PropertyQuery<int>, true);
       qp.close();
     });
 
-    tFloats.forEach((f) {
-      final qp = query.property(f);
-      expect(qp is DoublePropertyQuery, true);
+    tFloats.forEach((prop) {
+      final qp = query.property(prop);
+      expect(qp is PropertyQuery<double>, true);
       qp.close();
     });
 
     final qp = query.property(tString);
-    expect(qp is StringPropertyQuery, true);
+    expect(qp is PropertyQuery<String>, true);
     qp.close();
 
     query.close();
@@ -137,10 +137,10 @@ void main() {
     final sumInt = all.map((s) => toUint32(s.tInt!)).toList().fold(0, _add);
     final sumLong = all.map((s) => s.tLong!).toList().fold(0, _add);
 
-    expect(_propQueryExecInt(query, tByte, _pqSumInt), sumByte);
-    expect(_propQueryExecInt(query, tShort, _pqSumInt), sumShort);
-    expect(_propQueryExecInt(query, tInt, _pqSumInt), sumInt);
-    expect(_propQueryExecInt(query, tLong, _pqSumInt), sumLong);
+    expect(_propQueryExec(query, tByte, _pqSumInt), sumByte);
+    expect(_propQueryExec(query, tShort, _pqSumInt), sumShort);
+    expect(_propQueryExec(query, tInt, _pqSumInt), sumInt);
+    expect(_propQueryExec(query, tLong, _pqSumInt), sumLong);
 
     query.close();
   });
@@ -156,10 +156,10 @@ void main() {
     final minInt = all.map((s) => toUint32(s.tInt!)).toList().reduce(min);
     final minLong = all.map((s) => s.tLong!).toList().reduce(min);
 
-    expect(_propQueryExecInt(query, tByte, _pqMinInt), minByte);
-    expect(_propQueryExecInt(query, tShort, _pqMinInt), minShort);
-    expect(_propQueryExecInt(query, tInt, _pqMinInt), minInt);
-    expect(_propQueryExecInt(query, tLong, _pqMinInt), minLong);
+    expect(_propQueryExec(query, tByte, _pqMinInt), minByte);
+    expect(_propQueryExec(query, tShort, _pqMinInt), minShort);
+    expect(_propQueryExec(query, tInt, _pqMinInt), minInt);
+    expect(_propQueryExec(query, tLong, _pqMinInt), minLong);
 
     query.close();
   });
@@ -175,10 +175,10 @@ void main() {
     final maxInt = all.map((s) => toUint32(s.tInt!)).toList().reduce(max);
     final maxLong = all.map((s) => s.tLong!).toList().reduce(max);
 
-    expect(_propQueryExecInt(query, tByte, _pqMaxInt), maxByte);
-    expect(_propQueryExecInt(query, tShort, _pqMaxInt), maxShort);
-    expect(_propQueryExecInt(query, tInt, _pqMaxInt), maxInt);
-    expect(_propQueryExecInt(query, tLong, _pqMaxInt), maxLong);
+    expect(_propQueryExec(query, tByte, _pqMaxInt), maxByte);
+    expect(_propQueryExec(query, tShort, _pqMaxInt), maxShort);
+    expect(_propQueryExec(query, tInt, _pqMaxInt), maxInt);
+    expect(_propQueryExec(query, tLong, _pqMaxInt), maxLong);
 
     query.close();
   });
@@ -193,8 +193,8 @@ void main() {
     final sumFloat = all.map((s) => s.tFloat!).toList().fold(0.0, _add);
     final sumDouble = all.map((s) => s.tDouble!).toList().fold(0.0, _add);
 
-    expect(_propQueryExecDouble(query, tFloat, _pqSumDouble), sumFloat);
-    expect(_propQueryExecDouble(query, tDouble, _pqSumDouble), sumDouble);
+    expect(_propQueryExec(query, tFloat, _pqSumDouble), sumFloat);
+    expect(_propQueryExec(query, tDouble, _pqSumDouble), sumDouble);
 
     query.close();
   });
@@ -209,8 +209,8 @@ void main() {
     final minFloat = all.map((s) => s.tFloat!).toList().reduce(min);
     final minDouble = all.map((s) => s.tDouble!).toList().reduce(min);
 
-    expect(_propQueryExecDouble(query, tFloat, _pqMinDouble), minFloat);
-    expect(_propQueryExecDouble(query, tDouble, _pqMinDouble), minDouble);
+    expect(_propQueryExec(query, tFloat, _pqMinDouble), minFloat);
+    expect(_propQueryExec(query, tDouble, _pqMinDouble), minDouble);
 
     query.close();
   });
@@ -224,8 +224,8 @@ void main() {
     final maxFloat = all.map((s) => s.tFloat!).toList().reduce(max);
     final maxDouble = all.map((s) => s.tDouble!).toList().reduce(max);
 
-    expect(_propQueryExecDouble(query, tFloat, _pqMaxDouble), maxFloat);
-    expect(_propQueryExecDouble(query, tDouble, _pqMaxDouble), maxDouble);
+    expect(_propQueryExec(query, tFloat, _pqMaxDouble), maxFloat);
+    expect(_propQueryExec(query, tDouble, _pqMaxDouble), maxDouble);
 
     query.close();
   });
@@ -242,7 +242,7 @@ void main() {
 
     final start = [1, 2, 5];
     for (var i = 0; i < tSignedInts.length; i++) {
-      final qp = queryIntegers.property(tSignedInts[i]) as IntegerPropertyQuery;
+      final qp = queryIntegers.property(tSignedInts[i]);
 
       final mappedIntegers = integers.map((j) => j + start[i]).toList();
       expect(qp.find(replaceNullWith: -1), mappedIntegers);
@@ -252,7 +252,7 @@ void main() {
     }
 
     tFloats.forEach((f) {
-      final qp = queryFloats.property(f) as DoublePropertyQuery;
+      final qp = queryFloats.property(f);
 
       final increment = tFloat == f ? 0.1 : 0.2;
       final expected =
@@ -263,7 +263,7 @@ void main() {
       qp.close();
     });
 
-    final stringQuery = queryStrings.property(tString) as StringPropertyQuery;
+    final stringQuery = queryStrings.property(tString);
 
     // Note: results are in no particular order, so sort them before comparing.
     final defaultResults = [
@@ -323,8 +323,8 @@ void main() {
     var intUnsignedBaseAvg =
         integers.map(toUint32).reduce((a, b) => a + b) / integers.length;
 
-    final qpInteger = (QueryProperty p, double avg) {
-      final qp = queryIntegers.integerProperty(p);
+    final qpInteger = (QueryIntegerProperty<TestEntity> p, double avg) {
+      final qp = queryIntegers.property(p);
       expect(qp.average(), avg);
       qp.close();
     };
@@ -335,8 +335,8 @@ void main() {
     qpInteger(tShort, intBaseAvg + 2);
 
     // floats
-    final qpFloat = (QueryProperty p, double avg) {
-      final qp = queryFloats.doubleProperty(p);
+    final qpFloat = (QueryDoubleProperty<TestEntity> p, double avg) {
+      final qp = queryFloats.property(p);
       expect(qp.average().toStringAsFixed(2), avg.toStringAsFixed(2));
       qp.close();
     };
@@ -356,8 +356,9 @@ void main() {
     box.putMany(stringList());
 
     final queryStrings = box.query(tString.contains('t')).build();
-    final queryAndCheck = (QueryProperty prop, int valueIfNull, String reason) {
-      final qp = queryStrings.integerProperty(prop);
+    final queryAndCheck = (QueryIntegerProperty<TestEntity> prop,
+        int valueIfNull, String reason) {
+      final qp = queryStrings.property(prop);
       expect(qp.find(replaceNullWith: valueIfNull).first, valueIfNull,
           reason: reason);
       qp.close();
@@ -380,9 +381,9 @@ void main() {
     box.putMany(integerList());
 
     final queryIntegers = box.query(tLong.lessThan(1000)).build();
-    final queryAndCheck =
-        (QueryProperty prop, double valueIfNull, String reason) {
-      final qp = queryIntegers.doubleProperty(prop);
+    final queryAndCheck = (QueryDoubleProperty<TestEntity> prop,
+        double valueIfNull, String reason) {
+      final qp = queryIntegers.property(prop);
       expect(qp.find(replaceNullWith: valueIfNull).first, valueIfNull,
           reason: reason);
       qp.close();
@@ -399,7 +400,7 @@ void main() {
     box.putMany(floatList());
 
     final queryFloats = box.query(tDouble.lessThan(1000.0)).build();
-    final qp = queryFloats.stringProperty(tString);
+    final qp = queryFloats.property(tString);
     expect(qp.find(replaceNullWith: 't').first, 't');
     qp.close();
     queryFloats.close();
@@ -434,7 +435,7 @@ void main() {
     // string
     final query =
         box.query(tString.contains('t', caseSensitive: false)).build();
-    final queryString = query.property(tString) as StringPropertyQuery;
+    final queryString = query.property(tString);
 
     final allStrings = queryString.find()..sort();
     print('All items: $allStrings');
@@ -475,36 +476,28 @@ void main() {
 
 T _add<T extends num>(T lhs, T rhs) => (lhs + rhs) as T;
 
-T _propQueryExecInt<T>(Query query, QueryProperty prop,
-    T Function(IntegerPropertyQuery propQuery) fn) {
-  final propQuery = query.integerProperty(prop);
-  try {
-    return fn(propQuery);
-  } finally {
-    propQuery.close();
-  }
-}
-
-int _pqSumInt(IntegerPropertyQuery propQuery) => propQuery.sum();
-
-int _pqMinInt(IntegerPropertyQuery propQuery) => propQuery.min();
-
-int _pqMaxInt(IntegerPropertyQuery propQuery) => propQuery.max();
-
-T _propQueryExecDouble<T>(Query query, QueryProperty prop,
-    T Function(DoublePropertyQuery propQuery) fn) {
-  final propQuery = query.doubleProperty(prop);
-  try {
-    return fn(propQuery);
-  } finally {
-    propQuery.close();
-  }
-}
-
 int toUint32(int v) => v >= 0 ? v : (1 << 32) + v;
 
-double _pqSumDouble(DoublePropertyQuery propQuery) => propQuery.sum();
+T _propQueryExec<T, DartType>(
+    Query query,
+    QueryProperty<TestEntity, DartType> prop,
+    T Function(PropertyQuery<DartType> propQuery) fn) {
+  final propQuery = query.property(prop);
+  try {
+    return fn(propQuery);
+  } finally {
+    propQuery.close();
+  }
+}
 
-double _pqMinDouble(DoublePropertyQuery propQuery) => propQuery.min();
+int _pqSumInt(PropertyQuery<int> propQuery) => propQuery.sum();
 
-double _pqMaxDouble(DoublePropertyQuery propQuery) => propQuery.max();
+int _pqMinInt(PropertyQuery<int> propQuery) => propQuery.min();
+
+int _pqMaxInt(PropertyQuery<int> propQuery) => propQuery.max();
+
+double _pqSumDouble(PropertyQuery<double> propQuery) => propQuery.sum();
+
+double _pqMinDouble(PropertyQuery<double> propQuery) => propQuery.min();
+
+double _pqMaxDouble(PropertyQuery<double> propQuery) => propQuery.max();

--- a/objectbox/test/query_test.dart
+++ b/objectbox/test/query_test.dart
@@ -27,7 +27,7 @@ void main() {
     ]);
 
     var query =
-        box.query().order(TestEntity_.tInt, flags: Order.descending).build();
+        (box.query()..order(TestEntity_.tInt, flags: Order.descending)).build();
     final listDesc = query.find();
     query.close();
 
@@ -299,9 +299,9 @@ void main() {
     var q = box.query().build();
     expect(q.find().length, 4);
 
-    expect(q.offset(2).find().map((e) => e.tString), equals(['b', 'c']));
-    expect(q.limit(1).find().map((e) => e.tString), equals(['b']));
-    expect(q.offset(0).find().map((e) => e.tString), equals([null]));
+    expect((q..offset = 2).find().map((e) => e.tString), equals(['b', 'c']));
+    expect((q..limit = 1).find().map((e) => e.tString), equals(['b']));
+    expect((q..offset = 0).find().map((e) => e.tString), equals([null]));
 
     q.close();
   });
@@ -527,16 +527,15 @@ void main() {
 
     final condition = text.notNull();
 
-    final query = box.query(condition).order(text).build();
+    final query = (box.query(condition)..order(text)).build();
     final result1 = query.find().map((e) => e.tString).toList();
 
     expect('Cruel', result1[0]);
     expect('Hello', result1[2]);
     expect('HELLO', result1[3]);
 
-    final queryReverseOrder = box
-        .query(condition)
-        .order(text, flags: Order.descending | Order.caseSensitive)
+    final queryReverseOrder = (box.query(condition)
+          ..order(text, flags: Order.descending | Order.caseSensitive))
         .build();
     final result2 = queryReverseOrder.find().map((e) => e.tString).toList();
 
@@ -553,8 +552,8 @@ void main() {
       box.put(TestEntity(tLong: i, tInt: i));
     }
 
-    final querySigned = box.query().order(TestEntity_.tLong).build();
-    final queryUnsigned = box.query().order(TestEntity_.tInt).build();
+    final querySigned = (box.query()..order(TestEntity_.tLong)).build();
+    final queryUnsigned = (box.query()..order(TestEntity_.tInt)).build();
 
     expect(querySigned.findIds(), [1, 2, 3]);
     expect(queryUnsigned.findIds(), [2, 3, 1]);

--- a/objectbox/test/query_test.dart
+++ b/objectbox/test/query_test.dart
@@ -187,7 +187,8 @@ void main() {
     final t = TestEntity_.tString;
     final n = TestEntity_.tLong;
 
-    final checkQueryCount = (int expectedCount, Condition condition) {
+    final checkQueryCount =
+        (int expectedCount, Condition<TestEntity> condition) {
       final query = box.query(condition).build();
       expect(query.count(), expectedCount);
       query.close();
@@ -376,18 +377,18 @@ void main() {
     final text = TestEntity_.tString;
     final number = TestEntity_.tLong;
 
-    Condition cond1 = text.equals('Hello') | number.equals(1337);
-    Condition cond2 = text.equals('Hello') | number.equals(1337);
-    Condition cond3 =
+    Condition<TestEntity> cond1 = text.equals('Hello') | number.equals(1337);
+    Condition<TestEntity> cond2 = text.equals('Hello') | number.equals(1337);
+    Condition<TestEntity> cond3 =
         text.equals('What?').and(text.equals('Hello')).or(text.equals('World'));
-    Condition cond4 = text
+    Condition<TestEntity> cond4 = text
         .equals('Goodbye')
         .and(number.equals(1337))
         .or(number.equals(1337))
         .or(text.equals('Cruel'))
         .or(text.equals('World'));
-    Condition cond5 = text.equals('bleh') & number.equals(-1337);
-    Condition cond6 = text.equals('Hello') & number.equals(1337);
+    Condition<TestEntity> cond5 = text.equals('bleh') & number.equals(-1337);
+    Condition<TestEntity> cond6 = text.equals('Hello') & number.equals(1337);
 
     final q1 = box.query(cond1).build();
     final q2 = box.query(cond2).build();
@@ -409,7 +410,7 @@ void main() {
   test('.describe query', () {
     final text = TestEntity_.tString;
     final number = TestEntity_.tLong;
-    Condition c = text
+    Condition<TestEntity> c = text
         .equals('Goodbye')
         .and(number.equals(1337))
         .or(number.equals(1337))
@@ -451,7 +452,7 @@ void main() {
     final n = TestEntity_.id;
     final b = TestEntity_.tBool;
 
-    final check = (Condition condition, String text) {
+    final check = (Condition<TestEntity> condition, String text) {
       final q = box.query(condition).build();
       expect(q.describeParameters(), text);
       q.close();
@@ -472,7 +473,7 @@ void main() {
   test('.describeParameters query', () {
     final text = TestEntity_.tString;
     final number = TestEntity_.tLong;
-    Condition c = text
+    Condition<TestEntity> c = text
         .equals('Goodbye')
         .and(number.equals(1337))
         .or(number.equals(1337))

--- a/objectbox/test/stream_test.dart
+++ b/objectbox/test/stream_test.dart
@@ -22,10 +22,9 @@ void main() {
     final result = <String>[];
     final text = TestEntity_.tString;
     final condition = text.notNull();
-    final query = box.query(condition).order(text).build();
-    final queryStream = query.findStream();
-    final subscription = queryStream.listen((list) {
-      final str = list.map((t) => t.tString).toList().join(', ');
+    final query = (box.query(condition)..order(text)).build();
+    final subscription = query.stream.listen((q) {
+      final str = q.find().map((t) => t.tString).toList().join(', ');
       result.add(str);
     });
 
@@ -50,7 +49,7 @@ void main() {
     final result = <int>[];
     final text = TestEntity_.tString;
     final condition = text.notNull();
-    final query = box.query(condition).order(text).build();
+    final query = (box.query(condition)..order(text)).build();
     final queryStream = query.stream;
     final subscription = queryStream.listen((query) {
       result.add(query.count());
@@ -83,14 +82,12 @@ void main() {
     var counter1 = 0, counter2 = 0;
 
     final query2 = box2.query().build();
-    final queryStream2 = query2.findStream();
-    final subscription2 = queryStream2.listen((_) {
+    final subscription2 = query2.stream.listen((_) {
       counter2++;
     });
 
     final query1 = box.query().build();
-    final queryStream1 = query1.findStream();
-    final subscription1 = queryStream1.listen((_) {
+    final subscription1 = query1.stream.listen((_) {
       counter1++;
     });
 


### PR DESCRIPTION
closes #168 

* speeds up `getObjectBoxModel()` call significantly (~20 times while it still declared `_entities` list locally)
* makes queries (entity)type-safe
* reworks property queries to use extensions so users don't have to cast them all the time.

reviewing commit-by-commit should make most sense