### PR TITLE
Read speedup

### DIFF
--- a/generator/lib/src/code_chunks.dart
+++ b/generator/lib/src/code_chunks.dart
@@ -412,8 +412,8 @@ class CodeChunks {
       }
     });
 
-    return '''(Store store, Uint8List fbData) {
-      final buffer = fb.BufferContext.fromBytes(fbData);
+    return '''(Store store, ByteData fbData) {
+      final buffer = fb.BufferContext(fbData);
       final rootOffset = buffer.derefObject(0);
       ${preLines.join('\n')}
       final object = ${entity.name}(${constructorLines.join(', \n')})${cascadeLines.join('\n')};

--- a/objectbox/lib/flatbuffers/flat_buffers.dart
+++ b/objectbox/lib/flatbuffers/flat_buffers.dart
@@ -44,10 +44,10 @@ class BufferContext {
   factory BufferContext.fromBytes(List<int> byteList) {
     Uint8List uint8List = _asUint8List(byteList);
     ByteData buf = new ByteData.view(uint8List.buffer, uint8List.offsetInBytes);
-    return new BufferContext._(buf);
+    return new BufferContext(buf);
   }
 
-  BufferContext._(this._buffer);
+  BufferContext(this._buffer);
 
   @pragma('vm:prefer-inline')
   int derefObject(int offset) {
@@ -883,6 +883,7 @@ class Float32Reader extends Reader<double> {
 
 class Int64Reader extends Reader<int> {
   const Int64Reader() : super();
+
   @override
   int get size => _sizeofInt64;
 

--- a/objectbox/lib/src/modelinfo/entity_definition.dart
+++ b/objectbox/lib/src/modelinfo/entity_definition.dart
@@ -13,7 +13,7 @@ import 'modelentity.dart';
 class EntityDefinition<T> {
   final ModelEntity model;
   final int Function(T, fb.Builder) objectToFB;
-  final T Function(Store, Uint8List) objectFromFB;
+  final T Function(Store, ByteData) objectFromFB;
   final int? Function(T) getId;
   final void Function(T, int) setId;
   final List<ToOne> Function(T) toOneRelations;

--- a/objectbox/lib/src/native/bindings/data_visitor.dart
+++ b/objectbox/lib/src/native/bindings/data_visitor.dart
@@ -36,6 +36,7 @@ Pointer<NativeFunction<obx_data_visitor>> dataVisitor(
 Pointer<NativeFunction<obx_data_visitor>> objectCollector<T>(
         List<T> list, Store store, EntityDefinition<T> entity) =>
     dataVisitor((Pointer<Uint8> data, int size) {
-      list.add(entity.objectFromFB(store, data.asTypedList(size)));
+      list.add(entity.objectFromFB(
+          store, InternalStoreAccess.reader(store).access(data, size)));
       return true;
     });

--- a/objectbox/lib/src/native/bindings/flatbuffers.dart
+++ b/objectbox/lib/src/native/bindings/flatbuffers.dart
@@ -96,6 +96,8 @@ class Allocator extends fb.Allocator {
     assert(_data[_index] == data);
     assert(_allocs[_index].address != 0);
 
+    // TODO - there are other options to clear the builder, see how other
+    //        FlatBuffer implementations do it.
     memset(_allocs[_index], 0, data.lengthInBytes);
   }
 
@@ -113,7 +115,7 @@ class ReaderWithCBuffer {
   // See /benchmark/bin/native_pointers.dart for the max buffer size where it
   // still makes sense to use memcpy. On Linux, memcpy starts to be slower at
   // about 10-15 KiB. TODO test on other platforms to find an optimal limit.
-  static const _maxBuffer = 5 * 1024;
+  static const _maxBuffer = 4 * 1024;
   final _bufferPtr = malloc<Uint8>(_maxBuffer);
   late final ByteBuffer _buffer = _bufferPtr.asTypedList(_maxBuffer).buffer;
 

--- a/objectbox/lib/src/native/bindings/flatbuffers.dart
+++ b/objectbox/lib/src/native/bindings/flatbuffers.dart
@@ -1,10 +1,10 @@
 import 'dart:ffi';
-import 'dart:io' show Platform;
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
 
 import '../../../flatbuffers/flat_buffers.dart' as fb;
+import 'nativemem.dart';
 
 // ignore_for_file: public_member_api_docs
 
@@ -41,12 +41,6 @@ class BuilderWithCBuffer {
 
   Allocator get allocator => _allocator;
 }
-
-// FFI signature
-typedef _dart_memset = void Function(Pointer<Uint8>, int, int);
-typedef _c_memset = Void Function(Pointer<Uint8>, Int32, IntPtr);
-
-_dart_memset? fbMemset;
 
 class Allocator extends fb.Allocator {
   // We may, in practice, have only two active allocations: one used and one
@@ -98,34 +92,44 @@ class Allocator extends fb.Allocator {
   void clear(ByteData data, bool isFresh) {
     if (isFresh) return; // freshly allocated data is zero-ed out (see [calloc])
 
-    if (fbMemset == null) {
-      if (Platform.isWindows) {
-        try {
-          // DynamicLibrary.process() is not available on Windows, let's load a
-          // lib that defines 'memset()' it - should be mscvr100 or mscvrt DLL.
-          // mscvr100.dll is in the frequently installed MSVC Redistributable.
-          fbMemset = DynamicLibrary.open('msvcr100.dll')
-              .lookupFunction<_c_memset, _dart_memset>('memset');
-        } catch (_) {
-          // fall back if we can't load a native memset()
-          fbMemset = (Pointer<Uint8> ptr, int byte, int size) =>
-              ptr.cast<Uint8>().asTypedList(size).fillRange(0, size, byte);
-        }
-      } else {
-        fbMemset = DynamicLibrary.process()
-            .lookupFunction<_c_memset, _dart_memset>('memset');
-      }
-    }
-
     // only used for sanity checks:
     assert(_data[_index] == data);
     assert(_allocs[_index].address != 0);
 
-    fbMemset!(_allocs[_index], 0, data.lengthInBytes);
+    memset(_allocs[_index], 0, data.lengthInBytes);
   }
 
   void freeAll() {
     if (_allocs[0].address != 0) calloc.free(_allocs[0]);
     if (_allocs[1].address != 0) calloc.free(_allocs[1]);
+  }
+}
+
+/// Implements a native data access wrapper to circumvent Pointer.asTypedList()
+/// slowness. The idea is to reuse the same buffer and rather memcpy the data,
+/// which ends up being faster than calling asTypedList(). Hopefully, we will
+/// be able to remove this if (when) asTypedList() gets optimized in Dart SDK.
+class ReaderWithCBuffer {
+  // See /benchmark/bin/native_pointers.dart for the max buffer size where it
+  // still makes sense to use memcpy. On Linux, memcpy starts to be slower at
+  // about 10-15 KiB. TODO test on other platforms to find an optimal limit.
+  static const _maxBuffer = 5 * 1024;
+  final _bufferPtr = malloc<Uint8>(_maxBuffer);
+  late final ByteBuffer _buffer = _bufferPtr.asTypedList(_maxBuffer).buffer;
+
+  ReaderWithCBuffer() {
+    assert(_bufferPtr.asTypedList(_maxBuffer).offsetInBytes == 0);
+  }
+
+  void clear() => malloc.free(_bufferPtr);
+
+  ByteData access(Pointer<Uint8> dataPtr, int size) {
+    if (size > _maxBuffer) {
+      final uint8List = dataPtr.asTypedList(size);
+      return ByteData.view(uint8List.buffer, uint8List.offsetInBytes, size);
+    } else {
+      memcpy(_bufferPtr, dataPtr, size);
+      return ByteData.view(_buffer, 0, size);
+    }
   }
 }

--- a/objectbox/lib/src/native/bindings/helpers.dart
+++ b/objectbox/lib/src/native/bindings/helpers.dart
@@ -2,12 +2,12 @@ import 'dart:ffi';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
-import 'package:objectbox/src/native/bindings/flatbuffers.dart';
 
 import '../../common.dart';
 import '../../modelinfo/entity_definition.dart';
 import '../store.dart';
 import 'bindings.dart';
+import 'flatbuffers.dart';
 
 // ignore_for_file: public_member_api_docs
 
@@ -91,7 +91,7 @@ class CursorHelper<T> {
   late final ReaderWithCBuffer _reader = InternalStoreAccess.reader(_store);
 
   final bool _isWrite;
-  late final Pointer<Pointer<Void>> dataPtrPtr;
+  late final Pointer<Pointer<Uint8>> dataPtrPtr;
 
   late final Pointer<IntPtr> sizePtr;
 
@@ -108,8 +108,7 @@ class CursorHelper<T> {
     }
   }
 
-  ByteData get readData =>
-      _reader.access(dataPtrPtr.value.cast(), sizePtr.value);
+  ByteData get readData => _reader.access(dataPtrPtr.value, sizePtr.value);
 
   EntityDefinition<T> get entity => _entity;
 
@@ -133,13 +132,13 @@ class CursorHelper<T> {
 }
 
 T withNativeBytes<T>(
-    Uint8List data, T Function(Pointer<Void> ptr, int size) fn) {
+    Uint8List data, T Function(Pointer<Uint8> ptr, int size) fn) {
   final size = data.length;
   assert(size == data.lengthInBytes);
   final ptr = malloc<Uint8>(size);
   try {
     ptr.asTypedList(size).setAll(0, data); // copies `data` to `ptr`
-    return fn(ptr.cast<Void>(), size);
+    return fn(ptr, size);
   } finally {
     malloc.free(ptr);
   }

--- a/objectbox/lib/src/native/bindings/helpers.dart
+++ b/objectbox/lib/src/native/bindings/helpers.dart
@@ -2,6 +2,7 @@ import 'dart:ffi';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
+import 'package:objectbox/src/native/bindings/flatbuffers.dart';
 
 import '../../common.dart';
 import '../../modelinfo/entity_definition.dart';
@@ -87,6 +88,7 @@ class CursorHelper<T> {
   final EntityDefinition<T> _entity;
   final Store _store;
   final Pointer<OBX_cursor> ptr;
+  late final ReaderWithCBuffer _reader = InternalStoreAccess.reader(_store);
 
   final bool _isWrite;
   late final Pointer<Pointer<Void>> dataPtrPtr;
@@ -106,8 +108,8 @@ class CursorHelper<T> {
     }
   }
 
-  Uint8List get readData =>
-      dataPtrPtr.value.cast<Uint8>().asTypedList(sizePtr.value);
+  ByteData get readData =>
+      _reader.access(dataPtrPtr.value.cast(), sizePtr.value);
 
   EntityDefinition<T> get entity => _entity;
 

--- a/objectbox/lib/src/native/bindings/nativemem.dart
+++ b/objectbox/lib/src/native/bindings/nativemem.dart
@@ -1,0 +1,25 @@
+import 'dart:ffi';
+import 'dart:io';
+
+/// Provides native memory manipulation, operating on FFI Pointer<Void>.
+
+/// memset(ptr, value, num) sets the first num bytes of the block of memory
+/// pointed by ptr to the specified value (interpreted as an uint8).
+final _dart_memset memset =
+    _stdlib.lookupFunction<_c_memset, _dart_memset>('memset');
+
+/// memcpy (destination, source, num) copies the values of num bytes from the
+/// data pointed to by source to the memory block pointed to by destination.
+final _dart_memcpy memcpy =
+    _stdlib.lookupFunction<_c_memcpy, _dart_memcpy>('memcpy');
+
+// FFI signature
+typedef _dart_memset = void Function(Pointer<Uint8>, int, int);
+typedef _c_memset = Void Function(Pointer<Uint8>, Int32, IntPtr);
+
+typedef _dart_memcpy = void Function(Pointer<Uint8>, Pointer<Uint8>, int);
+typedef _c_memcpy = Void Function(Pointer<Uint8>, Pointer<Uint8>, IntPtr);
+
+final DynamicLibrary _stdlib = Platform.isWindows
+    ? DynamicLibrary.open('vcruntime140.dll') // required by objectbox.dll
+    : DynamicLibrary.process();

--- a/objectbox/lib/src/native/bindings/nativemem.dart
+++ b/objectbox/lib/src/native/bindings/nativemem.dart
@@ -20,6 +20,6 @@ typedef _c_memset = Void Function(Pointer<Uint8>, Int32, IntPtr);
 typedef _dart_memcpy = void Function(Pointer<Uint8>, Pointer<Uint8>, int);
 typedef _c_memcpy = Void Function(Pointer<Uint8>, Pointer<Uint8>, IntPtr);
 
-final DynamicLibrary _stdlib = Platform.isWindows
+final DynamicLibrary _stdlib = Platform.isWindows // no .process() on windows
     ? DynamicLibrary.open('vcruntime140.dll') // required by objectbox.dll
     : DynamicLibrary.process();

--- a/objectbox/lib/src/native/bindings/objectbox-c.dart
+++ b/objectbox/lib/src/native/bindings/objectbox-c.dart
@@ -1384,7 +1384,7 @@ class ObjectBoxC {
   int cursor_put(
     ffi.Pointer<OBX_cursor> cursor,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
   ) {
     return _cursor_put(
@@ -1409,7 +1409,7 @@ class ObjectBoxC {
   int cursor_put4(
     ffi.Pointer<OBX_cursor> cursor,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
     int mode,
   ) {
@@ -1435,7 +1435,7 @@ class ObjectBoxC {
   int cursor_put_new(
     ffi.Pointer<OBX_cursor> cursor,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
   ) {
     return _cursor_put_new(
@@ -1457,7 +1457,7 @@ class ObjectBoxC {
   int cursor_insert(
     ffi.Pointer<OBX_cursor> cursor,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
   ) {
     return _cursor_insert(
@@ -1479,7 +1479,7 @@ class ObjectBoxC {
   int cursor_update(
     ffi.Pointer<OBX_cursor> cursor,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
   ) {
     return _cursor_update(
@@ -1542,7 +1542,7 @@ class ObjectBoxC {
   int cursor_get(
     ffi.Pointer<OBX_cursor> cursor,
     int id,
-    ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+    ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
     ffi.Pointer<ffi.IntPtr> size,
   ) {
     return _cursor_get(
@@ -1577,7 +1577,7 @@ class ObjectBoxC {
 
   int cursor_first(
     ffi.Pointer<OBX_cursor> cursor,
-    ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+    ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
     ffi.Pointer<ffi.IntPtr> size,
   ) {
     return _cursor_first(
@@ -1594,7 +1594,7 @@ class ObjectBoxC {
 
   int cursor_next(
     ffi.Pointer<OBX_cursor> cursor,
-    ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+    ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
     ffi.Pointer<ffi.IntPtr> size,
   ) {
     return _cursor_next(
@@ -1626,7 +1626,7 @@ class ObjectBoxC {
 
   int cursor_current(
     ffi.Pointer<OBX_cursor> cursor,
-    ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+    ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
     ffi.Pointer<ffi.IntPtr> size,
   ) {
     return _cursor_current(
@@ -1956,7 +1956,7 @@ class ObjectBoxC {
   int box_get(
     ffi.Pointer<OBX_box> box,
     int id,
-    ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+    ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
     ffi.Pointer<ffi.IntPtr> size,
   ) {
     return _box_get(
@@ -2099,7 +2099,7 @@ class ObjectBoxC {
   int box_put(
     ffi.Pointer<OBX_box> box,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
   ) {
     return _box_put(
@@ -2120,7 +2120,7 @@ class ObjectBoxC {
   int box_insert(
     ffi.Pointer<OBX_box> box,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
   ) {
     return _box_insert(
@@ -2142,7 +2142,7 @@ class ObjectBoxC {
   int box_update(
     ffi.Pointer<OBX_box> box,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
   ) {
     return _box_update(
@@ -2165,7 +2165,7 @@ class ObjectBoxC {
   int box_put5(
     ffi.Pointer<OBX_box> box,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
     int mode,
   ) {
@@ -2555,7 +2555,7 @@ class ObjectBoxC {
   int async_put(
     ffi.Pointer<OBX_async> async_1,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
   ) {
     return _async_put(
@@ -2575,7 +2575,7 @@ class ObjectBoxC {
   int async_put5(
     ffi.Pointer<OBX_async> async_1,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
     int mode,
   ) {
@@ -2597,7 +2597,7 @@ class ObjectBoxC {
   int async_insert(
     ffi.Pointer<OBX_async> async_1,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
   ) {
     return _async_insert(
@@ -2617,7 +2617,7 @@ class ObjectBoxC {
   int async_update(
     ffi.Pointer<OBX_async> async_1,
     int id,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
   ) {
     return _async_update(
@@ -3366,7 +3366,7 @@ class ObjectBoxC {
   int qb_equals_bytes(
     ffi.Pointer<OBX_query_builder> builder,
     int property_id,
-    ffi.Pointer<ffi.Void> value,
+    ffi.Pointer<ffi.Uint8> value,
     int size,
   ) {
     return _qb_equals_bytes(
@@ -3385,7 +3385,7 @@ class ObjectBoxC {
   int qb_greater_than_bytes(
     ffi.Pointer<OBX_query_builder> builder,
     int property_id,
-    ffi.Pointer<ffi.Void> value,
+    ffi.Pointer<ffi.Uint8> value,
     int size,
   ) {
     return _qb_greater_than_bytes(
@@ -3405,7 +3405,7 @@ class ObjectBoxC {
   int qb_greater_or_equal_bytes(
     ffi.Pointer<OBX_query_builder> builder,
     int property_id,
-    ffi.Pointer<ffi.Void> value,
+    ffi.Pointer<ffi.Uint8> value,
     int size,
   ) {
     return _qb_greater_or_equal_bytes(
@@ -3426,7 +3426,7 @@ class ObjectBoxC {
   int qb_less_than_bytes(
     ffi.Pointer<OBX_query_builder> builder,
     int property_id,
-    ffi.Pointer<ffi.Void> value,
+    ffi.Pointer<ffi.Uint8> value,
     int size,
   ) {
     return _qb_less_than_bytes(
@@ -3446,7 +3446,7 @@ class ObjectBoxC {
   int qb_less_or_equal_bytes(
     ffi.Pointer<OBX_query_builder> builder,
     int property_id,
-    ffi.Pointer<ffi.Void> value,
+    ffi.Pointer<ffi.Uint8> value,
     int size,
   ) {
     return _qb_less_or_equal_bytes(
@@ -3763,7 +3763,7 @@ class ObjectBoxC {
   /// operation (e.g. put/remove) was executed. Accessing data after this is undefined behavior.
   int query_find_first(
     ffi.Pointer<OBX_query> query,
-    ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+    ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
     ffi.Pointer<ffi.IntPtr> size,
   ) {
     return _query_find_first(
@@ -3786,7 +3786,7 @@ class ObjectBoxC {
   /// operation (e.g. put/remove) was executed. Accessing data after this is undefined behavior.
   int query_find_unique(
     ffi.Pointer<OBX_query> query,
-    ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+    ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
     ffi.Pointer<ffi.IntPtr> size,
   ) {
     return _query_find_unique(
@@ -4159,7 +4159,7 @@ class ObjectBoxC {
     ffi.Pointer<OBX_query> query,
     int entity_id,
     int property_id,
-    ffi.Pointer<ffi.Void> value,
+    ffi.Pointer<ffi.Uint8> value,
     int size,
   ) {
     return _query_param_bytes(
@@ -4364,7 +4364,7 @@ class ObjectBoxC {
   int query_param_alias_bytes(
     ffi.Pointer<OBX_query> query,
     ffi.Pointer<ffi.Int8> alias,
-    ffi.Pointer<ffi.Void> value,
+    ffi.Pointer<ffi.Uint8> value,
     int size,
   ) {
     return _query_param_alias_bytes(
@@ -4930,7 +4930,7 @@ class ObjectBoxC {
   int bytes_array_set(
     ffi.Pointer<OBX_bytes_array> array,
     int index,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
   ) {
     return _bytes_array_set(
@@ -5160,7 +5160,7 @@ class ObjectBoxC {
   int sync_credentials(
     ffi.Pointer<OBX_sync> sync_1,
     int type,
-    ffi.Pointer<ffi.Void> data,
+    ffi.Pointer<ffi.Uint8> data,
     int size,
   ) {
     return _sync_credentials(
@@ -7095,21 +7095,21 @@ typedef _dart_cursor_id_for_put = int Function(
 typedef _c_cursor_put = ffi.Int32 Function(
   ffi.Pointer<OBX_cursor> cursor,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
 );
 
 typedef _dart_cursor_put = int Function(
   ffi.Pointer<OBX_cursor> cursor,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
 );
 
 typedef _c_cursor_put4 = ffi.Int32 Function(
   ffi.Pointer<OBX_cursor> cursor,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
   ffi.Int32 mode,
 );
@@ -7117,7 +7117,7 @@ typedef _c_cursor_put4 = ffi.Int32 Function(
 typedef _dart_cursor_put4 = int Function(
   ffi.Pointer<OBX_cursor> cursor,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
   int mode,
 );
@@ -7125,42 +7125,42 @@ typedef _dart_cursor_put4 = int Function(
 typedef _c_cursor_put_new = ffi.Int32 Function(
   ffi.Pointer<OBX_cursor> cursor,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
 );
 
 typedef _dart_cursor_put_new = int Function(
   ffi.Pointer<OBX_cursor> cursor,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
 );
 
 typedef _c_cursor_insert = ffi.Int32 Function(
   ffi.Pointer<OBX_cursor> cursor,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
 );
 
 typedef _dart_cursor_insert = int Function(
   ffi.Pointer<OBX_cursor> cursor,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
 );
 
 typedef _c_cursor_update = ffi.Int32 Function(
   ffi.Pointer<OBX_cursor> cursor,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
 );
 
 typedef _dart_cursor_update = int Function(
   ffi.Pointer<OBX_cursor> cursor,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
 );
 
@@ -7193,14 +7193,14 @@ typedef _dart_cursor_put_object4 = int Function(
 typedef _c_cursor_get = ffi.Int32 Function(
   ffi.Pointer<OBX_cursor> cursor,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
 typedef _dart_cursor_get = int Function(
   ffi.Pointer<OBX_cursor> cursor,
   int id,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
@@ -7214,25 +7214,25 @@ typedef _dart_cursor_get_all = ffi.Pointer<OBX_bytes_array> Function(
 
 typedef _c_cursor_first = ffi.Int32 Function(
   ffi.Pointer<OBX_cursor> cursor,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
 typedef _dart_cursor_first = int Function(
   ffi.Pointer<OBX_cursor> cursor,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
 typedef _c_cursor_next = ffi.Int32 Function(
   ffi.Pointer<OBX_cursor> cursor,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
 typedef _dart_cursor_next = int Function(
   ffi.Pointer<OBX_cursor> cursor,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
@@ -7248,13 +7248,13 @@ typedef _dart_cursor_seek = int Function(
 
 typedef _c_cursor_current = ffi.Int32 Function(
   ffi.Pointer<OBX_cursor> cursor,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
 typedef _dart_cursor_current = int Function(
   ffi.Pointer<OBX_cursor> cursor,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
@@ -7457,14 +7457,14 @@ typedef _dart_box_contains_many = int Function(
 typedef _c_box_get = ffi.Int32 Function(
   ffi.Pointer<OBX_box> box,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
 typedef _dart_box_get = int Function(
   ffi.Pointer<OBX_box> box,
   int id,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
@@ -7543,49 +7543,49 @@ typedef _dart_box_ids_for_put = int Function(
 typedef _c_box_put = ffi.Int32 Function(
   ffi.Pointer<OBX_box> box,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
 );
 
 typedef _dart_box_put = int Function(
   ffi.Pointer<OBX_box> box,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
 );
 
 typedef _c_box_insert = ffi.Int32 Function(
   ffi.Pointer<OBX_box> box,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
 );
 
 typedef _dart_box_insert = int Function(
   ffi.Pointer<OBX_box> box,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
 );
 
 typedef _c_box_update = ffi.Int32 Function(
   ffi.Pointer<OBX_box> box,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
 );
 
 typedef _dart_box_update = int Function(
   ffi.Pointer<OBX_box> box,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
 );
 
 typedef _c_box_put5 = ffi.Int32 Function(
   ffi.Pointer<OBX_box> box,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
   ffi.Int32 mode,
 );
@@ -7593,7 +7593,7 @@ typedef _c_box_put5 = ffi.Int32 Function(
 typedef _dart_box_put5 = int Function(
   ffi.Pointer<OBX_box> box,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
   int mode,
 );
@@ -7819,21 +7819,21 @@ typedef _dart_async_1 = ffi.Pointer<OBX_async> Function(
 typedef _c_async_put = ffi.Int32 Function(
   ffi.Pointer<OBX_async> async_1,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
 );
 
 typedef _dart_async_put = int Function(
   ffi.Pointer<OBX_async> async_1,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
 );
 
 typedef _c_async_put5 = ffi.Int32 Function(
   ffi.Pointer<OBX_async> async_1,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
   ffi.Int32 mode,
 );
@@ -7841,7 +7841,7 @@ typedef _c_async_put5 = ffi.Int32 Function(
 typedef _dart_async_put5 = int Function(
   ffi.Pointer<OBX_async> async_1,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
   int mode,
 );
@@ -7849,28 +7849,28 @@ typedef _dart_async_put5 = int Function(
 typedef _c_async_insert = ffi.Int32 Function(
   ffi.Pointer<OBX_async> async_1,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
 );
 
 typedef _dart_async_insert = int Function(
   ffi.Pointer<OBX_async> async_1,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
 );
 
 typedef _c_async_update = ffi.Int32 Function(
   ffi.Pointer<OBX_async> async_1,
   ffi.Uint64 id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
 );
 
 typedef _dart_async_update = int Function(
   ffi.Pointer<OBX_async> async_1,
   int id,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
 );
 
@@ -8357,70 +8357,70 @@ typedef _dart_qb_between_2doubles = int Function(
 typedef _c_qb_equals_bytes = ffi.Int32 Function(
   ffi.Pointer<OBX_query_builder> builder,
   ffi.Uint32 property_id,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   ffi.IntPtr size,
 );
 
 typedef _dart_qb_equals_bytes = int Function(
   ffi.Pointer<OBX_query_builder> builder,
   int property_id,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   int size,
 );
 
 typedef _c_qb_greater_than_bytes = ffi.Int32 Function(
   ffi.Pointer<OBX_query_builder> builder,
   ffi.Uint32 property_id,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   ffi.IntPtr size,
 );
 
 typedef _dart_qb_greater_than_bytes = int Function(
   ffi.Pointer<OBX_query_builder> builder,
   int property_id,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   int size,
 );
 
 typedef _c_qb_greater_or_equal_bytes = ffi.Int32 Function(
   ffi.Pointer<OBX_query_builder> builder,
   ffi.Uint32 property_id,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   ffi.IntPtr size,
 );
 
 typedef _dart_qb_greater_or_equal_bytes = int Function(
   ffi.Pointer<OBX_query_builder> builder,
   int property_id,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   int size,
 );
 
 typedef _c_qb_less_than_bytes = ffi.Int32 Function(
   ffi.Pointer<OBX_query_builder> builder,
   ffi.Uint32 property_id,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   ffi.IntPtr size,
 );
 
 typedef _dart_qb_less_than_bytes = int Function(
   ffi.Pointer<OBX_query_builder> builder,
   int property_id,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   int size,
 );
 
 typedef _c_qb_less_or_equal_bytes = ffi.Int32 Function(
   ffi.Pointer<OBX_query_builder> builder,
   ffi.Uint32 property_id,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   ffi.IntPtr size,
 );
 
 typedef _dart_qb_less_or_equal_bytes = int Function(
   ffi.Pointer<OBX_query_builder> builder,
   int property_id,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   int size,
 );
 
@@ -8592,25 +8592,25 @@ typedef _dart_query_find = ffi.Pointer<OBX_bytes_array> Function(
 
 typedef _c_query_find_first = ffi.Int32 Function(
   ffi.Pointer<OBX_query> query,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
 typedef _dart_query_find_first = int Function(
   ffi.Pointer<OBX_query> query,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
 typedef _c_query_find_unique = ffi.Int32 Function(
   ffi.Pointer<OBX_query> query,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
 typedef _dart_query_find_unique = int Function(
   ffi.Pointer<OBX_query> query,
-  ffi.Pointer<ffi.Pointer<ffi.Void>> data,
+  ffi.Pointer<ffi.Pointer<ffi.Uint8>> data,
   ffi.Pointer<ffi.IntPtr> size,
 );
 
@@ -8854,7 +8854,7 @@ typedef _c_query_param_bytes = ffi.Int32 Function(
   ffi.Pointer<OBX_query> query,
   ffi.Uint32 entity_id,
   ffi.Uint32 property_id,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   ffi.IntPtr size,
 );
 
@@ -8862,7 +8862,7 @@ typedef _dart_query_param_bytes = int Function(
   ffi.Pointer<OBX_query> query,
   int entity_id,
   int property_id,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   int size,
 );
 
@@ -8987,14 +8987,14 @@ typedef _dart_query_param_alias_2doubles = int Function(
 typedef _c_query_param_alias_bytes = ffi.Int32 Function(
   ffi.Pointer<OBX_query> query,
   ffi.Pointer<ffi.Int8> alias,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   ffi.IntPtr size,
 );
 
 typedef _dart_query_param_alias_bytes = int Function(
   ffi.Pointer<OBX_query> query,
   ffi.Pointer<ffi.Int8> alias,
-  ffi.Pointer<ffi.Void> value,
+  ffi.Pointer<ffi.Uint8> value,
   int size,
 );
 
@@ -9287,14 +9287,14 @@ typedef _dart_bytes_array = ffi.Pointer<OBX_bytes_array> Function(
 typedef _c_bytes_array_set = ffi.Int32 Function(
   ffi.Pointer<OBX_bytes_array> array,
   ffi.IntPtr index,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
 );
 
 typedef _dart_bytes_array_set = int Function(
   ffi.Pointer<OBX_bytes_array> array,
   int index,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
 );
 
@@ -9413,14 +9413,14 @@ typedef _dart_sync_close = int Function(
 typedef _c_sync_credentials = ffi.Int32 Function(
   ffi.Pointer<OBX_sync> sync_1,
   ffi.Int32 type,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   ffi.IntPtr size,
 );
 
 typedef _dart_sync_credentials = int Function(
   ffi.Pointer<OBX_sync> sync_1,
   int type,
-  ffi.Pointer<ffi.Void> data,
+  ffi.Pointer<ffi.Uint8> data,
   int size,
 );
 

--- a/objectbox/lib/src/native/bindings/objectbox-sync.h
+++ b/objectbox/lib/src/native/bindings/objectbox-sync.h
@@ -150,7 +150,7 @@ obx_err obx_sync_close(OBX_sync* sync);
 /// See OBXSyncCredentialsType for available options.
 /// The accepted OBXSyncCredentials type depends on your sync-server configuration.
 /// @param data may be NULL, i.e. in combination with OBXSyncCredentialsType_NONE
-obx_err obx_sync_credentials(OBX_sync* sync, OBXSyncCredentialsType type, const void* data, size_t size);
+obx_err obx_sync_credentials(OBX_sync* sync, OBXSyncCredentialsType type, const uint8_t* data, size_t size);
 
 /// Configures the maximum number of outgoing TX messages that can be sent without an ACK from the server.
 /// @returns OBX_ERROR_ILLEGAL_ARGUMENT if value is not in the range 1-20

--- a/objectbox/lib/src/native/bindings/objectbox.h
+++ b/objectbox/lib/src/native/bindings/objectbox.h
@@ -796,7 +796,7 @@ obx_id obx_cursor_id_for_put(OBX_cursor* cursor, obx_id id_or_zero);
 /// A "put" in ObjectBox follows "insert or update" semantics;
 /// New objects (no pre-existing object for given ID) are inserted while existing objects are replaced/updated.
 /// @param id non-zero
-obx_err obx_cursor_put(OBX_cursor* cursor, obx_id id, const void* data, size_t size);
+obx_err obx_cursor_put(OBX_cursor* cursor, obx_id id, const uint8_t* data, size_t size);
 
 /// Like put obx_cursor_put(), but takes an additional parameter (4th parameter) for choosing a put mode.
 /// @param id non-zero
@@ -804,24 +804,24 @@ obx_err obx_cursor_put(OBX_cursor* cursor, obx_id id, const void* data, size_t s
 /// @returns OBX_SUCCESS if the put operation was successful
 /// @returns OBX_ERROR_ID_ALREADY_EXISTS OBXPutMode_INSERT was used, but an existing object was found using the given ID
 /// @returns OBX_ERROR_ID_NOT_FOUND OBXPutMode_UPDATE was used, but no object was found for the given ID
-obx_err obx_cursor_put4(OBX_cursor* cursor, obx_id id, const void* data, size_t size, OBXPutMode mode);
+obx_err obx_cursor_put4(OBX_cursor* cursor, obx_id id, const uint8_t* data, size_t size, OBXPutMode mode);
 
 /// An optimized version of obx_cursor_put() if you can ensure that the given ID is not used yet.
 /// Typically used right after getting a new ID via obx_cursor_id_for_put().
 /// WARNING: using this incorrectly (an object with the given ID already exists) may result in inconsistent data
 /// (e.g. indexes do not get updated).
 /// @param id non-zero
-obx_err obx_cursor_put_new(OBX_cursor* cursor, obx_id id, const void* data, size_t size);
+obx_err obx_cursor_put_new(OBX_cursor* cursor, obx_id id, const uint8_t* data, size_t size);
 
 /// Convenience for obx_cursor_put4() with OBXPutMode_INSERT.
 /// @param id non-zero
 /// @returns OBX_ERROR_ID_ALREADY_EXISTS if an insert fails because of a colliding ID
-obx_err obx_cursor_insert(OBX_cursor* cursor, obx_id id, const void* data, size_t size);
+obx_err obx_cursor_insert(OBX_cursor* cursor, obx_id id, const uint8_t* data, size_t size);
 
 /// Convenience for obx_cursor_put4() with OBXPutMode_UPDATE.
 /// @param id non-zero
 /// @returns OBX_ERROR_ID_NOT_FOUND  if an update fails because the given ID does not represent any object
-obx_err obx_cursor_update(OBX_cursor* cursor, obx_id id, const void* data, size_t size);
+obx_err obx_cursor_update(OBX_cursor* cursor, obx_id id, const uint8_t* data, size_t size);
 
 /// FB ID slot must be present; new entities must prepare the slot using the special value OBX_ID_NEW.
 /// Alternatively, you may also pass 0 to indicate a new entity if you are aware that FlatBuffers builders typically
@@ -833,7 +833,7 @@ obx_id obx_cursor_put_object(OBX_cursor* cursor, void* data, size_t size);
 /// @overload obx_id obx_cursor_put_object(OBX_cursor* cursor, void* data, size_t size)
 obx_id obx_cursor_put_object4(OBX_cursor* cursor, void* data, size_t size, OBXPutMode mode);
 
-obx_err obx_cursor_get(OBX_cursor* cursor, obx_id id, const void** data, size_t* size);
+obx_err obx_cursor_get(OBX_cursor* cursor, obx_id id, const uint8_t** data, size_t* size);
 
 /// Get all objects as bytes.
 /// For larger quantities, it's recommended to iterate using obx_cursor_first and obx_cursor_next.
@@ -841,13 +841,13 @@ obx_err obx_cursor_get(OBX_cursor* cursor, obx_id id, const void** data, size_t*
 /// @returns NULL if the operation failed, see functions like obx_last_error_code() to get error details
 OBX_bytes_array* obx_cursor_get_all(OBX_cursor* cursor);
 
-obx_err obx_cursor_first(OBX_cursor* cursor, const void** data, size_t* size);
+obx_err obx_cursor_first(OBX_cursor* cursor, const uint8_t** data, size_t* size);
 
-obx_err obx_cursor_next(OBX_cursor* cursor, const void** data, size_t* size);
+obx_err obx_cursor_next(OBX_cursor* cursor, const uint8_t** data, size_t* size);
 
 obx_err obx_cursor_seek(OBX_cursor* cursor, obx_id id);
 
-obx_err obx_cursor_current(OBX_cursor* cursor, const void** data, size_t* size);
+obx_err obx_cursor_current(OBX_cursor* cursor, const uint8_t** data, size_t* size);
 
 obx_err obx_cursor_remove(OBX_cursor* cursor, obx_id id);
 
@@ -933,7 +933,7 @@ obx_err obx_box_contains_many(OBX_box* box, const OBX_id_array* ids, bool* out_c
 /// \attention The exposed data is only valid as long as the (top) transaction is still active and no write
 /// \attention operation (e.g. put/remove) was executed. Accessing data after this is undefined behavior.
 /// @returns OBX_ERROR_ILLEGAL_STATE if not inside of an active transaction (see obx_txn_read() and obx_txn_write())
-obx_err obx_box_get(OBX_box* box, obx_id id, const void** data, size_t* size);
+obx_err obx_box_get(OBX_box* box, obx_id id, const uint8_t** data, size_t* size);
 
 /// Fetch multiple objects for the given IDs from the box; must be called inside a (reentrant) transaction.
 /// \attention See obx_box_get() for important notes on the limited lifetime of the exposed data.
@@ -976,23 +976,23 @@ obx_err obx_box_ids_for_put(OBX_box* box, uint64_t count, obx_id* out_first_id);
 /// @param id An ID usually reserved via obx_box_id_for_put().
 /// @see obx_box_put5() to additionally provide a put mode
 /// @see obx_box_put_object() for a variant not requiring reserving IDs
-obx_err obx_box_put(OBX_box* box, obx_id id, const void* data, size_t size);
+obx_err obx_box_put(OBX_box* box, obx_id id, const uint8_t* data, size_t size);
 
 /// Convenience for obx_box_put5() with OBXPutMode_INSERT.
 /// @param id non-zero
 /// @returns OBX_ERROR_ID_ALREADY_EXISTS if an insert fails because of a colliding ID
-obx_err obx_box_insert(OBX_box* box, obx_id id, const void* data, size_t size);
+obx_err obx_box_insert(OBX_box* box, obx_id id, const uint8_t* data, size_t size);
 
 /// Convenience for obx_cursor_put4() with OBXPutMode_UPDATE.
 /// @param id non-zero
 /// @returns OBX_ERROR_ID_NOT_FOUND  if an update fails because the given ID does not represent any object
-obx_err obx_box_update(OBX_box* box, obx_id id, const void* data, size_t size);
+obx_err obx_box_update(OBX_box* box, obx_id id, const uint8_t* data, size_t size);
 
 /// Put the given object using the given ID synchronously; note that the ID also must match the one present in data.
 /// @param id An ID usually reserved via obx_box_id_for_put().
 /// @see obx_box_put() for standard put mode
 /// @see obx_box_put_object() for a variant not requiring reserving IDs
-obx_err obx_box_put5(OBX_box* box, obx_id id, const void* data, size_t size, OBXPutMode mode);
+obx_err obx_box_put5(OBX_box* box, obx_id id, const uint8_t* data, size_t size, OBXPutMode mode);
 
 /// FB ID slot must be present in the given data; new entities must have an ID value of zero or OBX_ID_NEW.
 /// @param data writable data buffer, which may be updated for the ID
@@ -1110,16 +1110,16 @@ typedef struct OBX_async OBX_async;
 OBX_async* obx_async(OBX_box* box);
 
 /// Put asynchronously with standard put semantics (insert or update).
-obx_err obx_async_put(OBX_async* async, obx_id id, const void* data, size_t size);
+obx_err obx_async_put(OBX_async* async, obx_id id, const uint8_t* data, size_t size);
 
 /// Put asynchronously using the given mode.
-obx_err obx_async_put5(OBX_async* async, obx_id id, const void* data, size_t size, OBXPutMode mode);
+obx_err obx_async_put5(OBX_async* async, obx_id id, const uint8_t* data, size_t size, OBXPutMode mode);
 
 /// Put asynchronously with inserts semantics (won't put if object already exists).
-obx_err obx_async_insert(OBX_async* async, obx_id id, const void* data, size_t size);
+obx_err obx_async_insert(OBX_async* async, obx_id id, const uint8_t* data, size_t size);
 
 /// Put asynchronously with update semantics (won't put if object is not yet present).
-obx_err obx_async_update(OBX_async* async, obx_id id, const void* data, size_t size);
+obx_err obx_async_update(OBX_async* async, obx_id id, const uint8_t* data, size_t size);
 
 /// Reserve an ID, which is returned immediately for future reference, and put asynchronously.
 /// Note: of course, it can NOT be guaranteed that the entity will actually be put successfully in the DB.
@@ -1284,18 +1284,18 @@ obx_qb_cond obx_qb_between_2doubles(OBX_query_builder* builder, obx_schema_id pr
 
 // Bytes (blob) conditions ---------------------
 
-obx_qb_cond obx_qb_equals_bytes(OBX_query_builder* builder, obx_schema_id property_id, const void* value, size_t size);
+obx_qb_cond obx_qb_equals_bytes(OBX_query_builder* builder, obx_schema_id property_id, const uint8_t* value, size_t size);
 
-obx_qb_cond obx_qb_greater_than_bytes(OBX_query_builder* builder, obx_schema_id property_id, const void* value,
+obx_qb_cond obx_qb_greater_than_bytes(OBX_query_builder* builder, obx_schema_id property_id, const uint8_t* value,
                                       size_t size);
 
-obx_qb_cond obx_qb_greater_or_equal_bytes(OBX_query_builder* builder, obx_schema_id property_id, const void* value,
+obx_qb_cond obx_qb_greater_or_equal_bytes(OBX_query_builder* builder, obx_schema_id property_id, const uint8_t* value,
                                           size_t size);
 
-obx_qb_cond obx_qb_less_than_bytes(OBX_query_builder* builder, obx_schema_id property_id, const void* value,
+obx_qb_cond obx_qb_less_than_bytes(OBX_query_builder* builder, obx_schema_id property_id, const uint8_t* value,
                                    size_t size);
 
-obx_qb_cond obx_qb_less_or_equal_bytes(OBX_query_builder* builder, obx_schema_id property_id, const void* value,
+obx_qb_cond obx_qb_less_or_equal_bytes(OBX_query_builder* builder, obx_schema_id property_id, const uint8_t* value,
                                        size_t size);
 
 /// Combine conditions[] to a new condition using operator AND (all).
@@ -1397,7 +1397,7 @@ OBX_bytes_array* obx_query_find(OBX_query* query);
 /// @warning Currently ignores offset, taking the the first matching element.
 /// @attention The exposed data is only valid as long as the (top) transaction is still active and no write
 ///            operation (e.g. put/remove) was executed. Accessing data after this is undefined behavior.
-obx_err obx_query_find_first(OBX_query* query, const void** data, size_t* size);
+obx_err obx_query_find_first(OBX_query* query, const uint8_t** data, size_t* size);
 
 /// Find the only object matching the query.
 /// @returns OBX_NOT_FOUND if no object matches, an error if there are multiple objects matching the query.
@@ -1405,7 +1405,7 @@ obx_err obx_query_find_first(OBX_query* query, const void** data, size_t* size);
 /// @warning Currently ignores offset and limit, considering all matching elements.
 /// @attention The exposed data is only valid as long as the (top) transaction is still active and no write
 ///            operation (e.g. put/remove) was executed. Accessing data after this is undefined behavior.
-obx_err obx_query_find_unique(OBX_query* query, const void** data, size_t* size);
+obx_err obx_query_find_unique(OBX_query* query, const uint8_t** data, size_t* size);
 
 /// Walk over matching objects using the given data visitor
 obx_err obx_query_visit(OBX_query* query, obx_data_visitor* visitor, void* user_data);
@@ -1457,7 +1457,7 @@ obx_err obx_query_param_int32s(OBX_query* query, obx_schema_id entity_id, obx_sc
 obx_err obx_query_param_double(OBX_query* query, obx_schema_id entity_id, obx_schema_id property_id, double value);
 obx_err obx_query_param_2doubles(OBX_query* query, obx_schema_id entity_id, obx_schema_id property_id, double value_a,
                                  double value_b);
-obx_err obx_query_param_bytes(OBX_query* query, obx_schema_id entity_id, obx_schema_id property_id, const void* value,
+obx_err obx_query_param_bytes(OBX_query* query, obx_schema_id entity_id, obx_schema_id property_id, const uint8_t* value,
                               size_t size);
 
 /// Gets the size of the property type used in a query condition.
@@ -1479,7 +1479,7 @@ obx_err obx_query_param_alias_int64s(OBX_query* query, const char* alias, const 
 obx_err obx_query_param_alias_int32s(OBX_query* query, const char* alias, const int32_t values[], size_t count);
 obx_err obx_query_param_alias_double(OBX_query* query, const char* alias, double value);
 obx_err obx_query_param_alias_2doubles(OBX_query* query, const char* alias, double value_a, double value_b);
-obx_err obx_query_param_alias_bytes(OBX_query* query, const char* alias, const void* value, size_t size);
+obx_err obx_query_param_alias_bytes(OBX_query* query, const char* alias, const uint8_t* value, size_t size);
 
 /// Gets the size of the property type used in a query condition.
 /// A typical use case of this is to allow language bindings (e.g. Swift) use the right type (e.g. 32 bit ints) even
@@ -1683,7 +1683,7 @@ void obx_bytes_free(OBX_bytes* bytes);
 OBX_bytes_array* obx_bytes_array(size_t count);
 
 /// Set the given data as the index in the bytes array. The data is not copied, just referenced through the pointer
-obx_err obx_bytes_array_set(OBX_bytes_array* array, size_t index, const void* data, size_t size);
+obx_err obx_bytes_array_set(OBX_bytes_array* array, size_t index, const uint8_t* data, size_t size);
 
 /// Free the bytes array struct
 void obx_bytes_array_free(OBX_bytes_array* array);

--- a/objectbox/lib/src/native/query/query.dart
+++ b/objectbox/lib/src/native/query/query.dart
@@ -19,7 +19,6 @@ import '../bindings/data_visitor.dart';
 import '../bindings/helpers.dart';
 
 part 'builder.dart';
-
 part 'property.dart';
 
 // ignore_for_file: public_member_api_docs
@@ -704,7 +703,8 @@ class Query<T> {
   T? findFirst() {
     T? result;
     final visitor = dataVisitor((Pointer<Uint8> data, int size) {
-      result = _entity.objectFromFB(_store, data.asTypedList(size));
+      result = _entity.objectFromFB(
+          _store, InternalStoreAccess.reader(_store).access(data, size));
       return false; // we only want to visit the first element
     });
     _store.runInTransaction(TxMode.read, () {
@@ -762,7 +762,8 @@ class Query<T> {
         // We expect Uint8List for data and NULL when the query has finished.
         if (message is Uint8List) {
           try {
-            controller.add(_entity.objectFromFB(_store, message));
+            controller.add(
+                _entity.objectFromFB(_store, ByteData.view(message.buffer)));
             return;
           } catch (e) {
             controller.addError(e);

--- a/objectbox/lib/src/native/query/query.dart
+++ b/objectbox/lib/src/native/query/query.dart
@@ -534,11 +534,11 @@ class _ByteVectorCondition<EntityT>
 
   int _op1(
           _QueryBuilder builder,
-          int Function(Pointer<OBX_query_builder>, int, Pointer<Void>, int)
+          int Function(Pointer<OBX_query_builder>, int, Pointer<Uint8>, int)
               func) =>
       withNativeBytes(
           _value,
-          (Pointer<Void> ptr, int size) =>
+              (Pointer<Uint8> ptr, int size) =>
               func(builder._cBuilder, _property._model.id.id, ptr, size));
 
   @override

--- a/objectbox/lib/src/native/store.dart
+++ b/objectbox/lib/src/native/store.dart
@@ -15,6 +15,7 @@ import '../modelinfo/index.dart';
 import '../transaction.dart';
 import '../util.dart';
 import 'bindings/bindings.dart';
+import 'bindings/flatbuffers.dart';
 import 'bindings/helpers.dart';
 import 'box.dart';
 import 'model.dart';
@@ -31,6 +32,7 @@ class Store {
   final ModelDefinition _defs;
   bool _closed = false;
   Stream<List<Type>>? _entityChanges;
+  final _reader = ReaderWithCBuffer();
 
   late final ByteData _reference;
 
@@ -198,6 +200,7 @@ class Store {
     _onClose.clear();
 
     if (!_weak) checkObx(C.store_close(_cStore));
+    _reader.clear();
   }
 
   /// Returns a cached Box instance.
@@ -297,6 +300,10 @@ class InternalStoreAccess {
   /// String query case-sensitive default
   @pragma('vm:prefer-inline')
   static bool queryCS(Store store) => store._queriesCaseSensitiveDefault;
+
+  /// The low-level pointer to this store.
+  @pragma('vm:prefer-inline')
+  static ReaderWithCBuffer reader(Store store) => store._reader;
 }
 
 const _int64Size = 8;

--- a/objectbox/lib/src/native/sync.dart
+++ b/objectbox/lib/src/native/sync.dart
@@ -207,7 +207,7 @@ class SyncClient {
     } else {
       withNativeBytes(
           creds._data,
-          (Pointer<Void> credsPtr, int credsSize) => checkObx(
+          (Pointer<Uint8> credsPtr, int credsSize) => checkObx(
               C.sync_credentials(_ptr, creds._type, credsPtr, credsSize)));
     }
   }

--- a/objectbox/pubspec.yaml
+++ b/objectbox/pubspec.yaml
@@ -36,6 +36,7 @@ ffigen:
   output: 'lib/src/native/bindings/objectbox-c.dart'
   headers:
     entry-points:
+      # NOTE: replace `const void*` by `const uint8_t*` in all objectbox*.h files when upgrading
       - 'lib/src/native/bindings/objectbox.h'
       - 'lib/src/native/bindings/objectbox-dart.h'
     include-directives:

--- a/objectbox/test/flatbuffers_test.dart
+++ b/objectbox/test/flatbuffers_test.dart
@@ -1,11 +1,12 @@
 import 'dart:ffi';
 import 'dart:typed_data';
 
+import 'package:objectbox/flatbuffers/flat_buffers.dart' as fb;
 // Note: upstream flatbuffers currently doesn't have a null-safe version
 // import 'package:flat_buffers/flat_buffers.dart' as fb_upstream;
 import 'package:objectbox/internal.dart';
 import 'package:objectbox/src/native/bindings/flatbuffers.dart';
-import 'package:objectbox/flatbuffers/flat_buffers.dart' as fb;
+import 'package:objectbox/src/native/bindings/nativemem.dart';
 import 'package:test/test.dart';
 
 import 'entity.dart';
@@ -107,7 +108,8 @@ void main() {
 
     final fb1 = BuilderWithCBuffer();
     binding.objectToFB(source, fb1.fbb);
-    final fbData = fb1.bufPtr.cast<Uint8>().asTypedList(fb1.fbb.size);
+    final fbData = ByteData.view(
+        fb1.bufPtr.cast<Uint8>().asTypedList(fb1.fbb.size).buffer);
 
     // must have the same content after reading back
     final target = binding.objectFromFB(env.store, fbData);
@@ -118,7 +120,7 @@ void main() {
     // checkSameEntities(target, source);
 
     // explicitly clear the allocated memory
-    fbMemset!(fb1.bufPtr.cast<Uint8>(), 0, fbData.lengthInBytes);
+    memset(fb1.bufPtr.cast<Uint8>(), 0, fbData.lengthInBytes);
     // fbData is now cleared as well, it's not a copy
     expect(bytesSum(fbData.buffer.asByteData()), isZero);
 

--- a/objectbox/test/query_test.dart
+++ b/objectbox/test/query_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:collection/collection.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
The dreaded `Pointer<Uint8>.asTypedList()` being sooo slooow didn't let me rest and it occurred to me to check whether using the same underlying pointer and instead copying the c-memory when reading objects wouldn't end up being faster, And yes, it did, by about a factor of 5 (evens out at about 10 KiB). So here's a PR improving overall read performance (in the flutter bench app) by about 80-100 %. 

As usual, commit-by-commit review recommended