### PR TITLE
Rename query property-meta classes for relations

### DIFF
--- a/generator/lib/src/code_chunks.dart
+++ b/generator/lib/src/code_chunks.dart
@@ -538,9 +538,14 @@ class CodeChunks {
 
       var propCode = '''
         /// see [${entity.name}.${propertyFieldName(prop)}]
-        static final ${propertyFieldName(prop)} = Query${fieldType}Property<${entity.name}''';
-      if (prop.isRelation) propCode += ', ${prop.relationTarget}';
-      propCode += '>(_entities[$i].properties[$p]);';
+        static final ${propertyFieldName(prop)} = ''';
+      if (prop.isRelation) {
+        propCode +=
+            'QueryRelationToOne<${entity.name}, ${prop.relationTarget}>';
+      } else {
+        propCode += 'Query${fieldType}Property<${entity.name}>';
+      }
+      propCode += '(_entities[$i].properties[$p]);';
       fields.add(propCode);
     }
 
@@ -550,7 +555,7 @@ class CodeChunks {
           entity.model.findEntityByUid(rel.targetId.uid)!.name;
       fields.add('''
           /// see [${entity.name}.${rel.name}]
-          static final ${rel.name} = QueryRelationMany'''
+          static final ${rel.name} = QueryRelationToMany'''
           '<${entity.name}, $targetEntityName>(_entities[$i].relations[$r]);');
     }
 

--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## latest
 
 * New `@Entity()` annotation field `type realClass` to support some custom code generators.
+* Rename semi-internal `QueryRelationProperty` to `QueryRelationToOne` and `QueryRelationMany` to `QueryRelationToMany`
+  to help users choosing the right link function: `link()`/`linkMany()`.
 * Fix `ToMany` showing duplicate items after adding them before reading the previous list.
 * Fix invalid native free during store shutdown if large data was inserted (more than 64 kilobytes flatbuffer).
 

--- a/objectbox/lib/src/native/query/builder.dart
+++ b/objectbox/lib/src/native/query/builder.dart
@@ -108,13 +108,13 @@ class _QueryBuilder<T> {
   }
 
   _QueryBuilder<TargetEntityT> link<TargetEntityT>(
-          QueryRelationProperty<T, TargetEntityT> rel,
+          QueryRelationToOne<T, TargetEntityT> rel,
           [Condition<TargetEntityT>? qc]) =>
       _QueryBuilder<TargetEntityT>._link(
           this, qc, C.qb_link_property(_cBuilder, rel._model.id.id));
 
   _QueryBuilder<SourceEntityT> backlink<SourceEntityT>(
-          QueryRelationProperty<SourceEntityT, T> rel,
+          QueryRelationToOne<SourceEntityT, T> rel,
           [Condition<SourceEntityT>? qc]) =>
       _QueryBuilder<SourceEntityT>._link(
           this,
@@ -125,13 +125,13 @@ class _QueryBuilder<T> {
               rel._model.id.id));
 
   _QueryBuilder<TargetEntityT> linkMany<TargetEntityT>(
-          QueryRelationMany<T, TargetEntityT> rel,
+          QueryRelationToMany<T, TargetEntityT> rel,
           [Condition<TargetEntityT>? qc]) =>
       _QueryBuilder<TargetEntityT>._link(
           this, qc, C.qb_link_standalone(_cBuilder, rel._model.id.id));
 
   _QueryBuilder<SourceEntityT> backlinkMany<SourceEntityT>(
-          QueryRelationMany<SourceEntityT, T> rel,
+          QueryRelationToMany<SourceEntityT, T> rel,
           [Condition<SourceEntityT>? qc]) =>
       _QueryBuilder<SourceEntityT>._link(
           this, qc, C.qb_backlink_standalone(_cBuilder, rel._model.id.id));

--- a/objectbox/lib/src/native/query/query.dart
+++ b/objectbox/lib/src/native/query/query.dart
@@ -210,15 +210,14 @@ class QueryStringVectorProperty<EntityT>
           caseSensitive: caseSensitive);
 }
 
-class QueryRelationProperty<Source, Target>
-    extends QueryIntegerProperty<Source> {
-  QueryRelationProperty(ModelProperty model) : super(model);
+class QueryRelationToOne<Source, Target> extends QueryIntegerProperty<Source> {
+  QueryRelationToOne(ModelProperty model) : super(model);
 }
 
-class QueryRelationMany<Source, Target> {
+class QueryRelationToMany<Source, Target> {
   final ModelRelation _model;
 
-  QueryRelationMany(this._model);
+  QueryRelationToMany(this._model);
 }
 
 enum _ConditionOp {


### PR DESCRIPTION
Seems like a good idea to help avoid the confusion in this SO question:

* https://stackoverflow.com/questions/67733318/tomany-relation-gives-type-error-at-link