### PR TITLE
reuse TX object (in order to reuse cursors)

### DIFF
--- a/objectbox/lib/src/native/transaction.dart
+++ b/objectbox/lib/src/native/transaction.dart
@@ -17,9 +17,9 @@ import 'bindings/helpers.dart';
 @internal
 class Transaction {
   final Store _store;
-  final bool _isWrite;
   final Pointer<OBX_txn> _cTxn;
   bool _closed = false;
+  final TxMode mode;
 
   // We have two ways of keeping cursors because we usually need just one.
   // The variable is faster then the map initialization & access.
@@ -28,9 +28,8 @@ class Transaction {
 
   Pointer<OBX_txn> get ptr => _cTxn;
 
-  Transaction(this._store, TxMode mode)
-      : _isWrite = mode == TxMode.write,
-        _cTxn = mode == TxMode.write
+  Transaction(this._store, this.mode)
+      : _cTxn = mode == TxMode.write
             ? C.txn_write(InternalStoreAccess.ptr(_store))
             : C.txn_read(InternalStoreAccess.ptr(_store)) {
     checkObxPtr(_cTxn, 'failed to create transaction');
@@ -38,7 +37,7 @@ class Transaction {
 
   @pragma('vm:prefer-inline')
   void _finish(bool successful) {
-    if (_isWrite) {
+    if (mode == TxMode.write) {
       try {
         _mark(successful);
       } finally {
@@ -83,7 +82,7 @@ class Transaction {
   CursorHelper<T> cursor<T>(EntityDefinition<T> entity) {
     if (_firstCursor == null) {
       return _firstCursor =
-          CursorHelper<T>(_store, _cTxn, entity, isWrite: _isWrite);
+          CursorHelper<T>(_store, _cTxn, entity, isWrite: mode == TxMode.write);
     } else if (_firstCursor!.entity == entity) {
       return _firstCursor as CursorHelper<T>;
     }
@@ -92,59 +91,8 @@ class Transaction {
     final cursors = _cursors!;
     if (!cursors.containsKey(entityId)) {
       cursors[entityId] =
-          CursorHelper<T>(_store, _cTxn, entity, isWrite: _isWrite);
+          CursorHelper<T>(_store, _cTxn, entity, isWrite: mode == TxMode.write);
     }
     return cursors[entityId] as CursorHelper<T>;
   }
-
-  /// Executes a given function inside a transaction.
-  ///
-  /// Returns type of [fn] if [return] is called in [fn].
-  @pragma('vm:prefer-inline')
-  static R execute<R>(Store store, TxMode mode, R Function() fn) {
-    // Whether the function is an `async` function. We can't allow those because
-    // the isolate could be transferred to another thread during execution.
-    // Checking the return value seems like the only thing we can in Dart v2.12.
-    if (fn is Future Function() && _nullSafetyEnabled) {
-      // This is a special case when the given function always throws. Triggered
-      //  in our test code. No need to even start a DB transaction in that case.
-      if (fn is Never Function()) {
-        // WARNING: don't be tempted to just `return fn();` - the code may
-        // execute DB operations which wouldn't be rolled back after the throw.
-        throw UnsupportedError('Given transaction callback always fails.');
-      }
-      throw UnsupportedError(
-          'Executing an "async" function in a transaction is not allowed.');
-    }
-
-    final tx = Transaction(store, mode);
-    try {
-      // In theory, we should only mark successful after the function finishes.
-      // In practice, it's safe to assume most functions will be successful and
-      // thus marking before the call allows us to return directly, before an
-      // intermediary variable.
-      if (tx._isWrite) tx.markSuccessful();
-      if (_nullSafetyEnabled) {
-        return fn();
-      } else {
-        final result = fn();
-        if (result is Future) {
-          // Let's make sure users change their code not to do use async.
-          throw UnsupportedError(
-              'Executing an "async" function in a transaction is not allowed.');
-        }
-        return result;
-      }
-    } catch (ex) {
-      if (tx._isWrite) tx.markFailed();
-      rethrow;
-    } finally {
-      tx.close();
-    }
-  }
 }
-
-/// True if the package enables null-safety (i.e. depends on SDK 2.12+).
-/// Otherwise, it's we can distinguish at runtime whether a function is async.
-final _nullSafetyEnabled = _nullReturningFn is! Future Function();
-final _nullReturningFn = () => null;

--- a/objectbox/test/box_test.dart
+++ b/objectbox/test/box_test.dart
@@ -621,4 +621,14 @@ void main() {
     expect(box.get(1)!.tString, str);
     env.store.close();
   });
+
+  test(
+      'TX multiple cursors',
+      () => store.runInTransaction(TxMode.write, () {
+            final box2 = store.box<TestEntity2>();
+            box.put(TestEntity());
+            box2.put(TestEntity2());
+            box.get(1);
+            box2.get(1);
+          }));
 }


### PR DESCRIPTION
While looking at test coverage I've noticed each `Transaction` object always held only a single cursor (i.e. the multi-cursor part wasn't ever hit). The investigation made me realize we're always creating a new dart `Transaction` instance (while only a single DB TX is used in the core so that's fine). This PR changes that to reuse the same object internally and reuse cursors.