### PR TITLE
flatbuffers - optimization for ASCII strings

### DIFF
--- a/objectbox/lib/flatbuffers/flat_buffers.dart
+++ b/objectbox/lib/flatbuffers/flat_buffers.dart
@@ -703,18 +703,48 @@ class Builder {
   }
 
   int _writeString(String value) {
-    // TODO(scheglov) optimize for ASCII strings
-    List<int> bytes = utf8.encode(value);
-    int length = bytes.length;
+    // [utf8.encode()] is slow (up to at least Dart SDK 2.13). If the given
+    // string is ASCII we can just write it directly, without any conversion.
+    final originalTail = _tail;
+    if (!_tryWriteASCIIString(value)) {
+      // reset the output buffer position for [_writeUTFString()]
+      _tail = originalTail;
+      _writeUTFString(value);
+    }
+    return _tail;
+  }
+
+  // Try to write the string as ASCII, return false if there's a non-ascii char.
+  @pragma('vm:prefer-inline')
+  bool _tryWriteASCIIString(String value) {
+    _prepare(4, 1, additionalBytes: value.length + 1);
+    final length = value.length;
+    var offset = _buf.lengthInBytes - _tail + 4;
+    for (var i = 0; i < length; i++) {
+      // utf16 code unit, e.g. for '†' it's [0x20 0x20], which is 8224 decimal.
+      // ASCII characters go from 0x00 to 0x7F (which is 0 to 127 decimal).
+      final char = value.codeUnitAt(i);
+      if (char >= 128) {
+        return false;
+      }
+      _buf.setUint8(offset++, char);
+    }
+    _buf.setUint8(offset, 0); // trailing zero
+    _setUint32AtTail(_buf, _tail, value.length);
+    return true;
+  }
+
+  @pragma('vm:prefer-inline')
+  void _writeUTFString(String value) {
+    final bytes = utf8.encode(value) as Uint8List;
+    final length = bytes.length;
     _prepare(4, 1, additionalBytes: length + 1);
-    final int result = _tail;
     _setUint32AtTail(_buf, _tail, length);
-    int offset = _buf.lengthInBytes - _tail + 4;
+    var offset = _buf.lengthInBytes - _tail + 4;
     for (int i = 0; i < length; i++) {
       _buf.setUint8(offset++, bytes[i]);
     }
     _buf.setUint8(offset, 0); // trailing zero
-    return result;
   }
 
   /// Throw an exception if there is not currently a vtable.

--- a/objectbox/test/flatbuffers_test.dart
+++ b/objectbox/test/flatbuffers_test.dart
@@ -83,6 +83,9 @@ void main() {
         as EntityDefinition<TestEntityNonRel>;
 
     final source = TestEntityNonRel.filled();
+    // Test the "dagger" char (0x20 0x20) which may cause problems if
+    // utf16/ascii isn't recognized properly.
+    source.tString = source.tString! + '†asdf';
 
     final fb1 = BuilderWithCBuffer();
     binding.objectToFB(source, fb1.fbb);


### PR DESCRIPTION
write directly without UTF16->UTF8 conversion unless needed.

why utf8.encode is so slow? in short, because it: 
1. allocates the whole buffer, up to the maximum size that may be needed if for utf8
2. converts to utf8
3. copies the buffer to a new list with the size of the actually needed buffer
4. the result is then again copied to the output flatbuffer

so two unnecessary allocations and two copies.

This PR takes the opportunistic approach and tries to copy directly to the output buffer, if the given string is ASCII

For ASCII strings, this shows the following improvements in benchmarks
* in plain flatbuffers benchmark - 30-40 % perf increase on Builder)
* in the flutter benchmark app (DB benchmarks - about 20 % increase of `putMany()` operations

For non-ASCII strings, it depends where the first non-ASCII character is, so not sure how to evaluate performance there...