### PR TITLE
On iOS use Dart API instead of memcpy

### DIFF
--- a/generator/integration-tests/part-partof/pubspec.yaml
+++ b/generator/integration-tests/part-partof/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
 dependencies:
   objectbox:
   json_serializable:
+  json_annotation: "^4.3.0"
   freezed_annotation:
 
 dev_dependencies:

--- a/objectbox/lib/src/native/bindings/flatbuffers.dart
+++ b/objectbox/lib/src/native/bindings/flatbuffers.dart
@@ -121,7 +121,9 @@ class ReaderWithCBuffer {
   void clear() => malloc.free(_bufferPtr);
 
   ByteData access(Pointer<Uint8> dataPtr, int size) {
-    if (size > _maxBuffer) {
+    // If memcpy is not available, instead of using Dart memcpy implementation,
+    // directly convert to view which is a little faster.
+    if (isMemcpyNotAvailable || size > _maxBuffer) {
       final uint8List = dataPtr.asTypedList(size);
       return ByteData.view(uint8List.buffer, uint8List.offsetInBytes, size);
     } else {

--- a/objectbox/lib/src/native/bindings/nativemem.dart
+++ b/objectbox/lib/src/native/bindings/nativemem.dart
@@ -8,13 +8,20 @@ import 'dart:io';
 final _dart_memset memset =
     _stdlib.lookupFunction<_c_memset, _dart_memset>('memset');
 
-/// If the native memcpy function should not be used.
-///
-/// memcpy is not available to Flutter on iOS 15 simulator,
-/// so use Dart API to copy data via asTypedList (which is much slower but works).
-///
-/// https://github.com/objectbox/objectbox-dart/issues/313
-final isMemcpyNotAvailable = Platform.isIOS;
+final _dart_memcpy? _memcpyNative = _lookupMemcpyOrNull();
+
+_dart_memcpy? _lookupMemcpyOrNull() {
+  try {
+    return _stdlib.lookupFunction<_c_memcpy, _dart_memcpy>('memcpy');
+  } catch (_) {
+    return null;
+  }
+}
+
+/// If the native memcpy function is not available
+/// and a Dart implementation is used.
+final isMemcpyNotAvailable = _memcpyNative == null;
+
 final _dart_memcpy _memcpyDart = (dest, src, length) {
   dest
       .asTypedList(length)
@@ -23,9 +30,12 @@ final _dart_memcpy _memcpyDart = (dest, src, length) {
 
 /// memcpy (destination, source, num) copies the values of num bytes from the
 /// data pointed to by source to the memory block pointed to by destination.
-final _dart_memcpy memcpy = isMemcpyNotAvailable
-    ? _memcpyDart
-    : _stdlib.lookupFunction<_c_memcpy, _dart_memcpy>('memcpy');
+///
+/// Note: the native memcpy might not be available
+/// (e.g. for Flutter on iOS 15 simulator), then a Dart implementation is used
+/// to copy data via asTypedList (which is much slower).
+/// https://github.com/objectbox/objectbox-dart/issues/313
+final _dart_memcpy memcpy = _memcpyNative ?? _memcpyDart;
 
 // FFI signature
 typedef _dart_memset = void Function(Pointer<Uint8>, int, int);


### PR DESCRIPTION
Workaround for #313 

If lookup of native memcpy function fails use a Dart implementation instead.
Except in case of `ReaderWithCBuffer` where a somewhat faster fallback implementation already exists (in case its shared buffer is too small it creates a new buffer and returns a view of it).

~To avoid the performance penalty on real devices might detect the iOS simulator. But this seems only possible using a Flutter plugin (based on an Apple flag available at compile time, e.g. see the [Flutter device_info_plus plugin](https://github.com/fluttercommunity/plus_plugins/blob/4e8a3122993c74fe9b57b472ab8c228899ff8e9a/packages/device_info_plus/device_info_plus/ios/Classes/FLTDeviceInfoPlusPlugin.m#L44-L53)).~

