### PR TITLE
Transaction: replace removed txn_mark_success

### DIFF
--- a/objectbox/lib/src/native/store.dart
+++ b/objectbox/lib/src/native/store.dart
@@ -308,16 +308,14 @@ class Store {
         throw UnsupportedError(
             'Executing an "async" function in a transaction is not allowed.');
       }
-      if (!reused && mode == TxMode.write) tx.markSuccessful();
+      if (!reused) tx.successAndClose();
       return result;
     } catch (ex) {
-      if (!reused && mode == TxMode.write) tx.markFailed();
+      // Is a no-op if successAndClose did throw.
+      if (!reused) tx.abortAndClose();
       rethrow;
     } finally {
-      if (!reused) {
-        tx.close();
-        _tx = null;
-      }
+      if (!reused) _tx = null;
     }
   }
 

--- a/objectbox/lib/src/relations/to_many.dart
+++ b/objectbox/lib/src/relations/to_many.dart
@@ -210,9 +210,11 @@ class ToMany<EntityT> extends Object with ListMixin<EntityT> {
             throw UnimplementedError();
         }
       });
-      if (ownedTx) tx.markSuccessful();
-    } finally {
-      if (ownedTx) tx.close();
+      if (ownedTx) tx.successAndClose();
+    } catch (ex) {
+      // Is a no-op if successAndClose did throw.
+      if (ownedTx) tx.abortAndClose();
+      rethrow;
     }
 
     _counts.clear();


### PR DESCRIPTION
Instead of marking write transactions successful or not (`obx_txn_mark_success`) and closing (`obx_txn_close`), use the C functions to mark successful and close (`obx_txn_success`) or just close (`obx_txn_close`).

That just [closing aborts the write transaction is tested](https://github.com/objectbox/objectbox-dart/blob/4a9152238e49182c8db6cc79512fcbfbf8690e6d/objectbox/test/box_test.dart#L517-L530).
