### PR TITLE
Make ToMany applyToDb work after putting empty ToMany

### DIFF
--- a/objectbox/lib/src/native/box.dart
+++ b/objectbox/lib/src/native/box.dart
@@ -360,8 +360,9 @@ class Box<T> {
 
   void _putToManyRelFields(T object, PutMode mode, Transaction tx) {
     _entity.toManyRelations(object).forEach((RelInfo info, ToMany rel) {
+      // Always set relation info so ToMany applyToDb can be used after initial put
+      InternalToManyAccess.setRelInfo(rel, _store, info, this);
       if (InternalToManyAccess.hasPendingDbChanges(rel)) {
-        InternalToManyAccess.setRelInfo(rel, _store, info, this);
         rel.applyToDb(mode: mode, tx: tx);
       }
     });

--- a/objectbox/test/observer_test.dart
+++ b/objectbox/test/observer_test.dart
@@ -43,9 +43,20 @@ void main() async {
     // expect two events after one put() and one putMany()
     expectedEvents = 2;
     completer = Completer();
-    box.put(simpleStringItems().first);
+    final first = simpleStringItems().first;
+    box.put(first);
     Box<TestEntity2>(env.store).put(TestEntity2());
     box.putMany(simpleStringItems());
+    await completer.future.timeout(defaultTimeout);
+    expect(expectedEvents, 0);
+
+    // expect one event after modifying ToMany
+    expectedEvents = 1;
+    completer = Completer();
+    first.relManyA.add(RelatedEntityA(tInt: 1));
+    // applyToDb does currently not trigger an event on the observed box
+    // first.relManyA.applyToDb();
+    box.put(first);
     await completer.future.timeout(defaultTimeout);
     expect(expectedEvents, 0);
 

--- a/objectbox/test/relations_test.dart
+++ b/objectbox/test/relations_test.dart
@@ -274,6 +274,37 @@ void main() {
       check(src!.relManyA, items: [1], added: [], removed: []);
     });
 
+    test('applyToDb', () {
+      final entity = src!;
+      expect(entity.relManyA, isNotNull);
+
+      // Put with empty ToMany
+      env.box.put(entity);
+      check(entity.relManyA, items: [], added: [], removed: []);
+
+      // Add one
+      entity.relManyA.add(RelatedEntityA(tInt: 1));
+      entity.relManyA.applyToDb();
+      check(entity.relManyA, items: [1], added: [], removed: []);
+
+      // Remove all
+      entity.relManyA.clear();
+      entity.relManyA.applyToDb();
+      check(entity.relManyA, items: [], added: [], removed: []);
+    });
+
+    test('applyToDb not attached throws', () {
+      final entity = src!;
+      expect(entity.relManyA, isNotNull);
+
+      entity.relManyA.add(RelatedEntityA(tInt: 1));
+      expect(
+          entity.relManyA.applyToDb,
+          throwsA(predicate((StateError e) => e
+              .toString()
+              .contains("ToMany relation field not initialized. Don't call applyToDb() on new objects, use box.put() instead."))));
+    });
+
     test("don't load old data when just adding", () {
       expect(src!.relManyA, isNotNull);
       src!.relManyA.add(RelatedEntityA(tInt: 1));


### PR DESCRIPTION
`applyToDb` currently only works after putting an object where the `ToMany` contains items, but not if it contaits no items. This bug existed since `0.11.0` where `ToMany` was initially introduced.