### PR TITLE
Support Unique conflict resolution strategy replace.

### DIFF
--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## latest
 
+* Support annotating a single property with `@Unique(onConflict: ConflictStrategy.replace)` to 
+  replace an existing object if a conflict occurs when doing a put. #297
+
 ## 1.2.1 (2021-11-09)
 
 * Fix Flutter apps crashing on iOS 15 simulator. #313

--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -1,3 +1,5 @@
+## latest
+
 ## 1.2.1 (2021-11-09)
 
 * Fix Flutter apps crashing on iOS 15 simulator. #313

--- a/objectbox/lib/src/annotations.dart
+++ b/objectbox/lib/src/annotations.dart
@@ -1,3 +1,5 @@
+import 'package:objectbox/objectbox.dart';
+
 /// Entity annotation is used on a class to let ObjectBox know it should store
 /// it - making the class a "persistable Entity".
 ///
@@ -190,17 +192,31 @@ enum IndexType {
   hash64,
 }
 
-/// Unique annotation forces that the value of a property is unique among all
-/// objects stored for the given entity.
+/// Enforces that the value of a property is unique among all objects in a box
+/// before an object can be put.
 ///
-/// Trying to put an Object with offending values will result in an exception.
+/// Trying to put an object with offending values will result in a
+/// [UniqueViolationException] (see [ConflictStrategy.fail]).
+/// Set [onConflict] to change this strategy.
 ///
-/// Unique properties are based on an [Index], so the same restrictions apply.
+/// Note: Unique properties are based on an [Index], so the same restrictions apply.
 /// It is supported to explicitly add the [Index] annotation to configure the
-/// index type.
+/// index.
 class Unique {
+  /// The strategy to use when a conflict is detected when an object is put.
+  final ConflictStrategy onConflict;
+
   /// Create a Unique annotation.
-  const Unique();
+  const Unique({this.onConflict = ConflictStrategy.fail});
+}
+
+/// Used with [Unique] to specify the conflict resolution strategy.
+enum ConflictStrategy {
+  /// Throws [UniqueViolationException] if any property violates a [Unique] constraint.
+  fail,
+
+  /// Any conflicting objects are deleted before the object is inserted.
+  replace,
 }
 
 /// Backlink annotation specifies a link in a reverse direction of another

--- a/objectbox/lib/src/modelinfo/enums.dart
+++ b/objectbox/lib/src/modelinfo/enums.dart
@@ -122,6 +122,9 @@ abstract class OBXPropertyFlags {
   /// ///
   /// /// For Time Series IDs, a companion property of type Date or DateNano represents the exact timestamp.
   static const int ID_COMPANION = 16384;
+
+  /// Unique on-conflict strategy: the object being put replaces any existing conflicting object (deletes it).
+  static const int UNIQUE_ON_CONFLICT_REPLACE = 32768;
 }
 
 abstract class OBXPropertyType {

--- a/objectbox/test/entity.dart
+++ b/objectbox/test/entity.dart
@@ -137,6 +137,11 @@ class TestEntity {
     this.uChar,
   }) : tString = '';
 
+  @Unique(onConflict: ConflictStrategy.replace)
+  int? replaceLong;
+
+  TestEntity.uniqueReplace({this.replaceLong, this.tString});
+
   @Property(type: PropertyType.byte)
   @Index()
   int? iByte;

--- a/objectbox/test/objectbox-model.json
+++ b/objectbox/test/objectbox-model.json
@@ -5,7 +5,7 @@
   "entities": [
     {
       "id": "1:4630700155272683157",
-      "lastPropertyId": "34:3975438751767916074",
+      "lastPropertyId": "35:1724663621433823504",
       "name": "TestEntity",
       "properties": [
         {
@@ -189,6 +189,13 @@
           "id": "34:3975438751767916074",
           "name": "tDateNano",
           "type": 12
+        },
+        {
+          "id": "35:1724663621433823504",
+          "name": "replaceLong",
+          "type": 6,
+          "flags": 32808,
+          "indexId": "20:4846837430056399798"
         }
       ],
       "relations": [
@@ -523,7 +530,7 @@
     }
   ],
   "lastEntityId": "10:8814538095619551454",
-  "lastIndexId": "19:3009172190024929732",
+  "lastIndexId": "20:4846837430056399798",
   "lastRelationId": "1:2155747579134420981",
   "lastSequenceId": "0:0",
   "modelVersion": 5,


### PR DESCRIPTION
#297

Add support for the replace conflict resolution strategy 
- to be used on at most one property,
- if Sync is enabled all `@Unique` properties must use `REPLACE` strategy (and with above rule at most one can exist).

# Tasks
- [x] Check if sync-enabled entity, all unique properties use `REPLACE`.
- [x] Add tests.
  - `build_runner` tests seem not possible (e.g. to verify errors on misconfigurations), so tested manually. 