### PR TITLE
Add an option to configure generator's output_dir

### DIFF
--- a/generator/integration-tests/config/.gitignore
+++ b/generator/integration-tests/config/.gitignore
@@ -1,0 +1,4 @@
+# start with an empty project, without a objectbox-model.json
+objectbox-model.json
+objectbox.*
+testdata

--- a/generator/integration-tests/config/1.dart
+++ b/generator/integration-tests/config/1.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+
+import 'lib/lib.dart';
+import 'lib/custom/objectbox.g.dart';
+import '../test_env.dart';
+import '../common.dart';
+
+void main() {
+  late TestEnv<A> env;
+  final jsonModel = readModelJson('lib/custom');
+  final defs = getObjectBoxModel();
+  final model = defs.model;
+
+  setUp(() {
+    env = TestEnv<A>(defs);
+  });
+
+  tearDown(() {
+    env.close();
+  });
+
+  commonModelTests(defs, jsonModel);
+
+  test('project must be generated properly', () {
+    expect(TestEnv.dir.existsSync(), true);
+    expect(File('lib/custom/objectbox.g.dart').existsSync(), true);
+    expect(File('lib/custom/objectbox-model.json').existsSync(), true);
+  });
+
+  // Very simple tests to ensure imports and generated code is correct.
+
+  test('types', () {
+    expect(property(model, 'A.text').type, OBXPropertyType.String);
+  });
+
+  test('db-ops-A', () {
+    final box = env.store.box<A>();
+    expect(box.count(), 0);
+
+    final inserted = A();
+    box.put(inserted);
+    expect(inserted.id, 1);
+    box.get(inserted.id!)!;
+  });
+}

--- a/generator/integration-tests/config/lib/custom/.keep
+++ b/generator/integration-tests/config/lib/custom/.keep
@@ -1,0 +1,1 @@
+This file just exists so its folder is created by git.

--- a/generator/integration-tests/config/lib/lib.dart
+++ b/generator/integration-tests/config/lib/lib.dart
@@ -1,0 +1,13 @@
+import 'dart:typed_data';
+
+import 'package:objectbox/objectbox.dart';
+
+import 'custom/objectbox.g.dart';
+
+@Entity()
+class A {
+  int? id;
+  String? text;
+
+  A();
+}

--- a/generator/integration-tests/config/pubspec.yaml
+++ b/generator/integration-tests/config/pubspec.yaml
@@ -1,0 +1,29 @@
+name: objectbox_generator_test
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+
+dependencies:
+  objectbox: any
+
+dev_dependencies:
+  objectbox_generator: any
+  test: any
+  build_runner: any
+  build_test: any
+  io: any
+  path: any
+
+dependency_overrides:
+  objectbox:
+    path: ../../../objectbox
+  objectbox_generator:
+    path: ../../
+
+
+objectbox:
+  output_dir: custom
+  # output_dir:
+  #   lib: custom
+  #   test: other
+

--- a/generator/lib/objectbox_generator.dart
+++ b/generator/lib/objectbox_generator.dart
@@ -1,10 +1,15 @@
 /// This package provides code generation for ObjectBox in Dart/Flutter.
+
 import 'package:build/build.dart';
-import 'src/entity_resolver.dart';
+
 import 'src/code_builder.dart';
+import 'src/config.dart';
+import 'src/entity_resolver.dart';
+
+final _config = Config.readFromPubspec();
 
 /// Finds all classes annotated with @Entity annotation and creates intermediate files for the generator.
 Builder entityResolverFactory(BuilderOptions options) => EntityResolver();
 
 /// Writes objectbox_model.dart and objectbox-model.json from the prepared .objectbox.info files found in the repo.
-Builder codeGeneratorFactory(BuilderOptions options) => CodeBuilder();
+Builder codeGeneratorFactory(BuilderOptions options) => CodeBuilder(_config);

--- a/generator/lib/src/config.dart
+++ b/generator/lib/src/config.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+
+const _pubspecFile = 'pubspec.yaml';
+const _pubspecKey = 'objectbox';
+
+/// Config reads and holds configuration for the code generator.
+///
+/// Expected format in pubspec.yaml:
+/// ```
+/// objectbox:
+///   output_dir: custom
+///   # Or optionally specify lib and test folder separately.
+///   # output_dir:
+///   #   lib: custom
+///   #   test: other
+/// ```
+class Config {
+  final String jsonFile;
+  final String codeFile;
+  final String outDirLib;
+  final String outDirTest;
+
+  Config._(
+      {String? jsonFile,
+      String? codeFile,
+      String? outDirLib,
+      String? outDirTest})
+      : jsonFile = jsonFile ?? 'objectbox-model.json',
+        codeFile = codeFile ?? 'objectbox.g.dart',
+        outDirLib = outDirLib ?? '',
+        outDirTest = outDirTest ?? '';
+
+  factory Config.readFromPubspec() {
+    final file = File(_pubspecFile);
+    if (file.existsSync()) {
+      final yaml = loadYaml(file.readAsStringSync())[_pubspecKey] as YamlMap?;
+      if (yaml != null) {
+        late final String? outDirLib;
+        late final String? outDirTest;
+        final outDirYaml = yaml['output_dir'];
+
+        if (outDirYaml is YamlMap) {
+          outDirLib = outDirYaml['lib'];
+          outDirTest = outDirYaml['test'];
+        } else {
+          outDirLib = outDirTest = outDirYaml as String?;
+        }
+
+        return Config._(outDirLib: outDirLib, outDirTest: outDirTest);
+      }
+    }
+    return Config._();
+  }
+}

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   path: ^1.8.0
   source_gen: ^1.0.0
   pubspec_parse: ^1.0.0
+  yaml: ^3.0.0
 
 # NOTE: remove before publishing
 dependency_overrides:

--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## latest
 
+* Add an option to change code-generator's `output_dir` in `pubspec.yaml`. #341
+
 ## 1.3.0 (2021-11-22)
 
 * Support annotating a single property with `@Unique(onConflict: ConflictStrategy.replace)` to 

--- a/objectbox/example/README.md
+++ b/objectbox/example/README.md
@@ -52,6 +52,18 @@ list (e.g. .gitignore), otherwise the build_runner will complain about it being 
 > annotations there. This is useful if you need a separate test DB. If you're just writing tests for your own code, you
 > won't have any annotations in the `test` folder so no DB will be created there.
 
+To customize the directory (relative to the package root) where the generated files are written,
+add the following to your `pubspec.yaml`:
+```
+objectbox:
+  # Writes objectbox-model.json and objectbox.g.dart to lib/custom (and test/custom).
+  output_dir: custom
+  # Or optionally specify the lib and test output folder separately.
+  # output_dir:
+  #   lib: custom
+  #   test: other
+```
+
 Creating a store
 ----------------
 


### PR DESCRIPTION
closes #312 

- [x] Check failed test: `custom` directory needs to exist.
- [x] Imports in generated code are wrong (assumes generated code file is in top-most directory).
- [x] Add documentation.
- [x] Clean up integration test (currently just copy/paste from `final` test).