### PR TITLE
Fix Flutter CI, migrate to lints from pedantic

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -28,8 +28,8 @@ jobs:
   init-script:
     runs-on: ubuntu-20.04
     steps:
-      - uses: subosito/flutter-action@v1
       - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v2
       - run: ./tool/init.sh
 
   lib:
@@ -93,12 +93,12 @@ jobs:
           - stable
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: subosito/flutter-action@v1
+      - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}
       - run: echo $PATH
       - run: flutter --version
-      - uses: actions/checkout@v2
       - if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: ./tool/apt-install.sh ninja-build pkg-config libgtk-3-dev
       - run: make integration-test

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v2
+        with:
+          cache: true
       - run: ./tool/init.sh
 
   lib:
@@ -97,6 +99,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}
+          cache: true
       - run: echo $PATH
       - run: flutter --version
       - if: ${{ startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -100,6 +100,10 @@ jobs:
         with:
           channel: ${{ matrix.channel }}
           cache: true
+      - uses: actions/setup-java@v2 # macos-10.15 and windows-2019 default to Java 8, but Android Plugin requires 11
+        with:
+          distribution: 'temurin'
+          java-version: '11'
       - run: echo $PATH
       - run: flutter --version
       - if: ${{ startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v2
+        with:
+          cache: true
       - name: Generage test coverage
         working-directory: objectbox
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,8 +43,8 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: subosito/flutter-action@v1
       - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v2
       - name: Generage test coverage
         working-directory: objectbox
         run: |

--- a/benchmark/lib/benchmark.dart
+++ b/benchmark/lib/benchmark.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:meta/meta.dart';
-import 'package:objectbox/objectbox.dart';
 
 import 'model.dart';
 import 'objectbox.g.dart';

--- a/generator/analysis_options.yaml
+++ b/generator/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 linter:
   rules:

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -19,6 +19,9 @@ dependencies:
   pubspec_parse: ^1.0.0
   yaml: ^3.0.0
 
+dev_dependencies:
+  lints: ^1.0.1
+
 # NOTE: remove before publishing
 dependency_overrides:
   objectbox:

--- a/objectbox/analysis_options.yaml
+++ b/objectbox/analysis_options.yaml
@@ -1,6 +1,5 @@
-include: package:pedantic/analysis_options.yaml
-# Effective dart has some things we don't use so let's stick with pedantic for now
-# include: package:effective_dart/analysis_options.yaml
+include: package:lints/recommended.yaml
+# https://dart.dev/guides/language/analysis-options
 
 linter:
   # Some additional rules from pub.dev analyzer and package:effective_dart

--- a/objectbox/lib/src/annotations.dart
+++ b/objectbox/lib/src/annotations.dart
@@ -1,4 +1,4 @@
-import 'package:objectbox/objectbox.dart';
+import '../objectbox.dart';
 
 /// Entity annotation is used on a class to let ObjectBox know it should store
 /// it - making the class a "persistable Entity".

--- a/objectbox/lib/src/native/bindings/bindings.dart
+++ b/objectbox/lib/src/native/bindings/bindings.dart
@@ -116,12 +116,12 @@ Object? _dartAPIInitException;
 
 /// A couple of native functions we need as callbacks to pass back to native.
 /// Unfortunately, ffigen keeps those private.
-typedef _native_close = Int32 Function(Pointer<Void> ptr);
+typedef _NativeClose = Int32 Function(Pointer<Void> ptr);
 
 late final native_query_close =
-    _lib!.lookup<NativeFunction<_native_close>>('obx_query_close');
+    _lib!.lookup<NativeFunction<_NativeClose>>('obx_query_close');
 late final native_query_prop_close =
-    _lib!.lookup<NativeFunction<_native_close>>('obx_query_prop_close');
+    _lib!.lookup<NativeFunction<_NativeClose>>('obx_query_prop_close');
 
 /// Keeps `this` alive until this call, preventing finalizers to run.
 /// Necessary for objects with a finalizer attached because the optimizer may

--- a/objectbox/lib/src/native/bindings/nativemem.dart
+++ b/objectbox/lib/src/native/bindings/nativemem.dart
@@ -5,14 +5,14 @@ import 'dart:io';
 
 /// memset(ptr, value, num) sets the first num bytes of the block of memory
 /// pointed by ptr to the specified value (interpreted as an uint8).
-final _dart_memset memset =
-    _stdlib.lookupFunction<_c_memset, _dart_memset>('memset');
+final _DartMemset memset =
+    _stdlib.lookupFunction<_CMemset, _DartMemset>('memset');
 
-final _dart_memcpy? _memcpyNative = _lookupMemcpyOrNull();
+final _DartMemcpy? _memcpyNative = _lookupMemcpyOrNull();
 
-_dart_memcpy? _lookupMemcpyOrNull() {
+_DartMemcpy? _lookupMemcpyOrNull() {
   try {
-    return _stdlib.lookupFunction<_c_memcpy, _dart_memcpy>('memcpy');
+    return _stdlib.lookupFunction<_CMemcpy, _DartMemcpy>('memcpy');
   } catch (_) {
     return null;
   }
@@ -22,7 +22,7 @@ _dart_memcpy? _lookupMemcpyOrNull() {
 /// and a Dart implementation is used.
 final isMemcpyNotAvailable = _memcpyNative == null;
 
-final _dart_memcpy _memcpyDart = (dest, src, length) {
+final _DartMemcpy _memcpyDart = (dest, src, length) {
   dest
       .asTypedList(length)
       .setAll(0, src.asTypedList(length).getRange(0, length));
@@ -35,14 +35,14 @@ final _dart_memcpy _memcpyDart = (dest, src, length) {
 /// (e.g. for Flutter on iOS 15 simulator), then a Dart implementation is used
 /// to copy data via asTypedList (which is much slower).
 /// https://github.com/objectbox/objectbox-dart/issues/313
-final _dart_memcpy memcpy = _memcpyNative ?? _memcpyDart;
+final _DartMemcpy memcpy = _memcpyNative ?? _memcpyDart;
 
 // FFI signature
-typedef _dart_memset = void Function(Pointer<Uint8>, int, int);
-typedef _c_memset = Void Function(Pointer<Uint8>, Int32, IntPtr);
+typedef _DartMemset = void Function(Pointer<Uint8>, int, int);
+typedef _CMemset = Void Function(Pointer<Uint8>, Int32, IntPtr);
 
-typedef _dart_memcpy = void Function(Pointer<Uint8>, Pointer<Uint8>, int);
-typedef _c_memcpy = Void Function(Pointer<Uint8>, Pointer<Uint8>, IntPtr);
+typedef _DartMemcpy = void Function(Pointer<Uint8>, Pointer<Uint8>, int);
+typedef _CMemcpy = Void Function(Pointer<Uint8>, Pointer<Uint8>, IntPtr);
 
 final DynamicLibrary _stdlib = Platform.isWindows // no .process() on windows
     ? DynamicLibrary.open('vcruntime140.dll') // required by objectbox.dll

--- a/objectbox/lib/src/native/box.dart
+++ b/objectbox/lib/src/native/box.dart
@@ -16,7 +16,6 @@ import 'bindings/bindings.dart';
 import 'bindings/flatbuffers.dart';
 import 'bindings/helpers.dart';
 import 'query/query.dart';
-import 'transaction.dart';
 
 /// Box put (write) mode.
 enum PutMode {

--- a/objectbox/pubspec.yaml
+++ b/objectbox/pubspec.yaml
@@ -20,9 +20,9 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.0.0
   objectbox_generator: any
-  pedantic: ^1.11.0
   test: ^1.16.5
   ffigen: ^2.4.2
+  lints: ^1.0.1
 
 # NOTE: remove before publishing
 dependency_overrides:

--- a/objectbox/test/boxnn_test.dart
+++ b/objectbox/test/boxnn_test.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
 
-import 'package:test/test.dart';
 import 'package:objectbox/objectbox.dart';
+import 'package:test/test.dart';
+
 import 'entity.dart';
 import 'test_env.dart';
 

--- a/objectbox/test/isolates_test.dart
+++ b/objectbox/test/isolates_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:isolate';
 import 'dart:typed_data';
 
-import 'package:objectbox/objectbox.dart';
 import 'package:test/test.dart';
 
 import 'entity.dart';

--- a/objectbox/test/query_property_test.dart
+++ b/objectbox/test/query_property_test.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:objectbox/internal.dart';
-import 'package:objectbox/objectbox.dart';
 import 'package:test/test.dart';
 
 import 'entity.dart';

--- a/objectbox/test/sync_test.dart
+++ b/objectbox/test/sync_test.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:objectbox/objectbox.dart';
 import 'package:objectbox/internal.dart';
 import 'package:objectbox/src/native/store.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
- [ ] pedantic is discontinued and new checks use lints. Need to fix analysis issues to get perfect package score again.
- [x] Enable cache for https://github.com/subosito/flutter-action
  - Cache key does not include version, so not sure if this will always get latest Flutter from channel. Need to check with next Flutter release.