### PR TITLE
Migrate from pedantic to lints

### DIFF
--- a/benchmark/lib/benchmark.dart
+++ b/benchmark/lib/benchmark.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:meta/meta.dart';
-import 'package:objectbox/objectbox.dart';
 
 import 'model.dart';
 import 'objectbox.g.dart';

--- a/generator/analysis_options.yaml
+++ b/generator/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 linter:
   rules:

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -19,6 +19,9 @@ dependencies:
   pubspec_parse: ^1.0.0
   yaml: ^3.0.0
 
+dev_dependencies:
+  lints: ^1.0.1
+
 # NOTE: remove before publishing
 dependency_overrides:
   objectbox:

--- a/objectbox/analysis_options.yaml
+++ b/objectbox/analysis_options.yaml
@@ -27,13 +27,11 @@ analyzer:
   errors:
     public_member_api_docs: error
     type_annotate_public_apis: error
+  # Note: pana ignores these exclude rules, better add ignore_for_file comments.
   exclude:
     - example/**
     - generator/**
     - benchmark/**
-    - lib/src/modelinfo/enums.dart
-    - lib/src/native/bindings/objectbox-c.dart
-    - lib/flatbuffers/** # Not really our code
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false

--- a/objectbox/analysis_options.yaml
+++ b/objectbox/analysis_options.yaml
@@ -1,6 +1,5 @@
-include: package:pedantic/analysis_options.yaml
-# Effective dart has some things we don't use so let's stick with pedantic for now
-# include: package:effective_dart/analysis_options.yaml
+include: package:lints/recommended.yaml
+# https://dart.dev/guides/language/analysis-options
 
 linter:
   # Some additional rules from pub.dev analyzer and package:effective_dart

--- a/objectbox/lib/src/annotations.dart
+++ b/objectbox/lib/src/annotations.dart
@@ -1,4 +1,4 @@
-import 'package:objectbox/objectbox.dart';
+import '../objectbox.dart';
 
 /// Entity annotation is used on a class to let ObjectBox know it should store
 /// it - making the class a "persistable Entity".

--- a/objectbox/lib/src/modelinfo/enums.dart
+++ b/objectbox/lib/src/modelinfo/enums.dart
@@ -1,6 +1,8 @@
 // Note: the enums in this file are copied from native/bindings/objectbox-c.dart
 // to avoid package:ffi import which would break compatibility with web.
 
+// ignore_for_file: public_member_api_docs, constant_identifier_names
+
 import '../annotations.dart';
 
 /// Maps [OBXPropertyType] to its string representation (name).

--- a/objectbox/lib/src/native/bindings/bindings.dart
+++ b/objectbox/lib/src/native/bindings/bindings.dart
@@ -116,12 +116,12 @@ Object? _dartAPIInitException;
 
 /// A couple of native functions we need as callbacks to pass back to native.
 /// Unfortunately, ffigen keeps those private.
-typedef _native_close = Int32 Function(Pointer<Void> ptr);
+typedef _NativeClose = Int32 Function(Pointer<Void> ptr);
 
 late final native_query_close =
-    _lib!.lookup<NativeFunction<_native_close>>('obx_query_close');
+    _lib!.lookup<NativeFunction<_NativeClose>>('obx_query_close');
 late final native_query_prop_close =
-    _lib!.lookup<NativeFunction<_native_close>>('obx_query_prop_close');
+    _lib!.lookup<NativeFunction<_NativeClose>>('obx_query_prop_close');
 
 /// Keeps `this` alive until this call, preventing finalizers to run.
 /// Necessary for objects with a finalizer attached because the optimizer may

--- a/objectbox/lib/src/native/bindings/nativemem.dart
+++ b/objectbox/lib/src/native/bindings/nativemem.dart
@@ -5,14 +5,14 @@ import 'dart:io';
 
 /// memset(ptr, value, num) sets the first num bytes of the block of memory
 /// pointed by ptr to the specified value (interpreted as an uint8).
-final _dart_memset memset =
-    _stdlib.lookupFunction<_c_memset, _dart_memset>('memset');
+final _DartMemset memset =
+    _stdlib.lookupFunction<_CMemset, _DartMemset>('memset');
 
-final _dart_memcpy? _memcpyNative = _lookupMemcpyOrNull();
+final _DartMemcpy? _memcpyNative = _lookupMemcpyOrNull();
 
-_dart_memcpy? _lookupMemcpyOrNull() {
+_DartMemcpy? _lookupMemcpyOrNull() {
   try {
-    return _stdlib.lookupFunction<_c_memcpy, _dart_memcpy>('memcpy');
+    return _stdlib.lookupFunction<_CMemcpy, _DartMemcpy>('memcpy');
   } catch (_) {
     return null;
   }
@@ -22,7 +22,7 @@ _dart_memcpy? _lookupMemcpyOrNull() {
 /// and a Dart implementation is used.
 final isMemcpyNotAvailable = _memcpyNative == null;
 
-final _dart_memcpy _memcpyDart = (dest, src, length) {
+final _DartMemcpy _memcpyDart = (dest, src, length) {
   dest
       .asTypedList(length)
       .setAll(0, src.asTypedList(length).getRange(0, length));
@@ -35,14 +35,14 @@ final _dart_memcpy _memcpyDart = (dest, src, length) {
 /// (e.g. for Flutter on iOS 15 simulator), then a Dart implementation is used
 /// to copy data via asTypedList (which is much slower).
 /// https://github.com/objectbox/objectbox-dart/issues/313
-final _dart_memcpy memcpy = _memcpyNative ?? _memcpyDart;
+final _DartMemcpy memcpy = _memcpyNative ?? _memcpyDart;
 
 // FFI signature
-typedef _dart_memset = void Function(Pointer<Uint8>, int, int);
-typedef _c_memset = Void Function(Pointer<Uint8>, Int32, IntPtr);
+typedef _DartMemset = void Function(Pointer<Uint8>, int, int);
+typedef _CMemset = Void Function(Pointer<Uint8>, Int32, IntPtr);
 
-typedef _dart_memcpy = void Function(Pointer<Uint8>, Pointer<Uint8>, int);
-typedef _c_memcpy = Void Function(Pointer<Uint8>, Pointer<Uint8>, IntPtr);
+typedef _DartMemcpy = void Function(Pointer<Uint8>, Pointer<Uint8>, int);
+typedef _CMemcpy = Void Function(Pointer<Uint8>, Pointer<Uint8>, IntPtr);
 
 final DynamicLibrary _stdlib = Platform.isWindows // no .process() on windows
     ? DynamicLibrary.open('vcruntime140.dll') // required by objectbox.dll

--- a/objectbox/lib/src/native/bindings/objectbox-c.dart
+++ b/objectbox/lib/src/native/bindings/objectbox-c.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: non_constant_identifier_names, public_member_api_docs, prefer_expression_function_bodies, avoid_positional_boolean_parameters, constant_identifier_names, camel_case_types
+// ignore_for_file: non_constant_identifier_names, public_member_api_docs, prefer_expression_function_bodies, avoid_positional_boolean_parameters, constant_identifier_names, camel_case_types, file_names
 
 // AUTO GENERATED FILE, DO NOT EDIT.
 //

--- a/objectbox/lib/src/native/bindings/objectbox-c.dart
+++ b/objectbox/lib/src/native/bindings/objectbox-c.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, public_member_api_docs, prefer_expression_function_bodies, avoid_positional_boolean_parameters, constant_identifier_names, camel_case_types
 
 // AUTO GENERATED FILE, DO NOT EDIT.
 //

--- a/objectbox/lib/src/native/box.dart
+++ b/objectbox/lib/src/native/box.dart
@@ -16,7 +16,6 @@ import 'bindings/bindings.dart';
 import 'bindings/flatbuffers.dart';
 import 'bindings/helpers.dart';
 import 'query/query.dart';
-import 'transaction.dart';
 
 /// Box put (write) mode.
 enum PutMode {

--- a/objectbox/lib/src/native/observable.dart
+++ b/objectbox/lib/src/native/observable.dart
@@ -111,12 +111,6 @@ extension ObservableStore on Store {
       final entities = List<Type>.filled(entityIds.length, Null);
       for (var i = 0; i < entityIds.length; i++) {
         final entityId = entityIds[i];
-        if (entityId is! int) {
-          observer.controller.addError(ObjectBoxException(
-              'Received invalid item data format from the core notification: (${entityId.runtimeType}) $entityId'));
-          return;
-        }
-
         final entityType = entityTypesById[entityId];
         if (entityType == null) {
           observer.controller.addError(ObjectBoxException(

--- a/objectbox/pubspec.yaml
+++ b/objectbox/pubspec.yaml
@@ -20,9 +20,9 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.0.0
   objectbox_generator: any
-  pedantic: ^1.11.0
   test: ^1.16.5
   ffigen: ^2.4.2
+  lints: ^1.0.1
 
 # NOTE: remove before publishing
 dependency_overrides:

--- a/objectbox/pubspec.yaml
+++ b/objectbox/pubspec.yaml
@@ -54,5 +54,6 @@ ffigen:
   compiler-opts: '-I/usr/lib/clang/11.1.0/include'
   typedef-map:
     'size_t': 'IntPtr'
+  # pana ignores exclude rules in analysis_options.yaml, explicitly add ignore rules.
   preamble: |
-    // ignore_for_file: non_constant_identifier_names
+    // ignore_for_file: non_constant_identifier_names, public_member_api_docs, prefer_expression_function_bodies, avoid_positional_boolean_parameters, constant_identifier_names, camel_case_types

--- a/objectbox/test/boxnn_test.dart
+++ b/objectbox/test/boxnn_test.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
 
-import 'package:test/test.dart';
 import 'package:objectbox/objectbox.dart';
+import 'package:test/test.dart';
+
 import 'entity.dart';
 import 'test_env.dart';
 

--- a/objectbox/test/isolates_test.dart
+++ b/objectbox/test/isolates_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:isolate';
 import 'dart:typed_data';
 
-import 'package:objectbox/objectbox.dart';
 import 'package:test/test.dart';
 
 import 'entity.dart';

--- a/objectbox/test/query_property_test.dart
+++ b/objectbox/test/query_property_test.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:objectbox/internal.dart';
-import 'package:objectbox/objectbox.dart';
 import 'package:test/test.dart';
 
 import 'entity.dart';

--- a/objectbox/test/sync_test.dart
+++ b/objectbox/test/sync_test.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:objectbox/objectbox.dart';
 import 'package:objectbox/internal.dart';
 import 'package:objectbox/src/native/store.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
pedantic is discontinued and replaced by lints. Update to it and update code to pass new rules.

- [x] Fix analysis issues to get perfect package score again.