### PR TITLE
Add Store.runIsolated to run database ops in the background

### DIFF
--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Support [ObjectBox Admin](https://docs.objectbox.io/data-browser) for Android apps to browse 
   the database. #148
+* Add `Store.runIsolated` to run database operations (asynchronous) in the background. It spawns an
+  isolate, runs the given callback in that isolate with its own Store and returns the result of the
+  callback. This is similar to Flutters compute, but with the callback having access to a Store.
 * Add `Store.attach` to attach to a Store opened in a directory. This is an improved replacement for 
   `Store.fromReference` to share a Store across isolates. It is no longer required to pass a
   Store reference and the underlying Store remains open until the last instance is closed. #376

--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 * Support [ObjectBox Admin](https://docs.objectbox.io/data-browser) for Android apps to browse 
   the database. #148
-* Add `Store.runIsolated` to run database operations (asynchronous) in the background. It spawns an
-  isolate, runs the given callback in that isolate with its own Store and returns the result of the
-  callback. This is similar to Flutters compute, but with the callback having access to a Store.
+* Add `Store.runIsolated` to run database operations (asynchronous) in the background 
+  (requires Flutter 2.8.0/Dart 2.15.0 or newer). It spawns an isolate, runs the given callback in that 
+  isolate with its own Store and returns the result of the callback. This is similar to Flutters 
+  compute, but with the callback having access to a Store. #384
 * Add `Store.attach` to attach to a Store opened in a directory. This is an improved replacement for 
   `Store.fromReference` to share a Store across isolates. It is no longer required to pass a
   Store reference and the underlying Store remains open until the last instance is closed. #376

--- a/objectbox/lib/src/native/store.dart
+++ b/objectbox/lib/src/native/store.dart
@@ -399,6 +399,9 @@ class Store {
   ///
   /// Instances of [callback] must be top-level functions or static methods
   /// of classes, not closures or instance methods of objects.
+  ///
+  /// Note: this requires Dart 2.15.0 or newer
+  /// (shipped with Flutter 2.8.0 or newer).
   Future<R> runIsolated<P, R>(
       TxMode mode, FutureOr<R> Function(Store, P) callback, P param) async {
     final resultPort = ReceivePort();

--- a/objectbox/test/basics_test.dart
+++ b/objectbox/test/basics_test.dart
@@ -207,7 +207,7 @@ void main() {
   });
 }
 
-String readStringAndRemove(Store store, int id) {
+Future<String> readStringAndRemove(Store store, int id) async {
   var box = store.box<TestEntity>();
   var testEntity = box.get(id);
   final result = testEntity!.tString! + '!';
@@ -215,7 +215,8 @@ String readStringAndRemove(Store store, int id) {
   final removed = box.remove(id);
   print('Removed in 2nd isolate: $removed');
   print('Count in 2nd isolate after remove: ${box.count()}');
-  return result;
+  // Pointless Future to test async functions are supported.
+  return await Future.delayed(const Duration(milliseconds: 10), () => result);
 }
 
 class StoreAttachIsolateInit {


### PR DESCRIPTION
Similar to Flutter compute, but with the callable having access to a Store within the isolate.

- [x] This depends on the new Store.attach API #376, rebase before merging.