### PR TITLE
Immutable entities with copyWithId setter

### DIFF
--- a/generator/lib/src/code_builder.dart
+++ b/generator/lib/src/code_builder.dart
@@ -209,6 +209,7 @@ class CodeBuilder extends Builder {
     propInModel.name = prop.name;
     propInModel.type = prop.type;
     propInModel.flags = prop.flags;
+    propInModel.generatorFlags = prop.generatorFlags;
     propInModel.dartFieldType = prop.dartFieldType;
     propInModel.relationTarget = prop.relationTarget;
 

--- a/generator/lib/src/code_chunks.dart
+++ b/generator/lib/src/code_chunks.dart
@@ -125,7 +125,8 @@ class CodeChunks {
       id: ${createIdUid(property.id)},
       name: '${property.name}',
       type: ${property.type},
-      flags: ${property.flags}
+      flags: ${property.flags},
+      generatorFlags: ${property.generatorFlags}
       $additionalArgs
     )
     ''';
@@ -180,8 +181,12 @@ class CodeChunks {
   }
 
   static String setId(ModelEntity entity) {
+    if (entity.idProperty
+        .hasGeneratorFlag(OBXPropertyGeneratorFlags.USE_COPY_WITH_ID)) {
+      return '{return object.copyWithId(id);}';
+    }
     if (!entity.idProperty.fieldIsReadOnly) {
-      return '{object.${propertyFieldName(entity.idProperty)} = id;}';
+      return '{object.${propertyFieldName(entity.idProperty)} = id; return object;}';
     }
     // Note: this is a special case handling read-only IDs with assignable=true.
     // Such ID must already be set, i.e. it could not have been assigned.
@@ -193,6 +198,7 @@ class CodeChunks {
         "doesn't match the inserted ID (ID \$id). "
         'You must assign an ID before calling [box.put()].');
       }
+      return object;
     }''';
   }
 

--- a/objectbox/Makefile
+++ b/objectbox/Makefile
@@ -11,22 +11,22 @@ help:			## Show this help
 all: depend test valgrind-test integration-test
 
 depend:			## Build dependencies
-	pub get
+	dart pub get 
 	../install.sh
 
 test: 			## Test all targets
-	pub run build_runner build
-	pub run test
+	dart run build_runner build
+	dart run test
 
 coverage: 			## Calculate test coverage
-	pub run build_runner build
+	dart run build_runner build
     # Note: only flutter test generates `.lcov` - can't use `dart test`
 	flutter test --coverage
 	lcov --remove coverage/lcov.info 'lib/src/native/sync.dart' 'lib/src/native/bindings/objectbox_c.dart' 'lib/src/native/bindings/bindings.dart' 'lib/src/modelinfo/*' -o coverage/lcov.info
 	genhtml coverage/lcov.info -o coverage/html || true
 
 valgrind-test: 		## Test all targets with valgrind
-	pub run build_runner build
+	dart run build_runner build
 	./tool/valgrind.sh
 
 integration-test:	## Execute integration tests

--- a/objectbox/lib/src/annotations.dart
+++ b/objectbox/lib/src/annotations.dart
@@ -134,8 +134,33 @@ class Id {
   /// telling which objects are new and which are already saved.
   final bool assignable;
 
+  /// Use copyWith new id in the entity identifier setter.
+  /// For example, if your entity is immutable object,
+  /// you can define idSetter as follows
+  ///
+  /// @Entity()
+  /// class ImmutableEntity {
+  ///   @Id(idSetter: _idSetter)
+  ///   final int? id;
+  ///
+  ///   final int payload;
+  ///
+  ///   ImmutableEntity copyWith({int? id, int? unique, int? payload}) =>
+  ///       ImmutableEntity(
+  ///         id: id,
+  ///         unique: unique ?? this.unique,
+  ///         payload: payload ?? this.payload,
+  ///       );
+  ///
+  ///   ImmutableEntity{this.id, required this.unique, required this.payload});
+  ///
+  ///   static ImmutableEntity copyWithId(ImmutableEntity entity, int newId) =>
+  ///       entity.copyWith(id: newId);
+  /// }
+  final bool useCopyWith;
+
   /// Create an Id annotation.
-  const Id({this.assignable = false});
+  const Id({this.assignable = false, this.useCopyWith = false});
 }
 
 /// Transient annotation marks fields that should not be stored in the database.

--- a/objectbox/lib/src/modelinfo/entity_definition.dart
+++ b/objectbox/lib/src/modelinfo/entity_definition.dart
@@ -16,7 +16,7 @@ class EntityDefinition<T> {
   final int Function(T, fb.Builder) objectToFB;
   final T Function(Store, ByteData) objectFromFB;
   final int? Function(T) getId;
-  final void Function(T, int) setId;
+  final T Function(T, int) setId;
   final List<ToOne> Function(T) toOneRelations;
   final Map<RelInfo, ToMany> Function(T) toManyRelations;
 

--- a/objectbox/lib/src/modelinfo/enums.dart
+++ b/objectbox/lib/src/modelinfo/enums.dart
@@ -138,6 +138,11 @@ abstract class OBXPropertyFlags {
   static const int UNIQUE_ON_CONFLICT_REPLACE = 32768;
 }
 
+abstract class OBXPropertyGeneratorFlags {
+  /// Use copyWithId in id setter
+  static const int USE_COPY_WITH_ID = 65536;
+}
+
 abstract class OBXPropertyType {
   /// < 1 byte
   static const int Bool = 1;

--- a/objectbox/lib/src/modelinfo/modelproperty.dart
+++ b/objectbox/lib/src/modelinfo/modelproperty.dart
@@ -10,7 +10,7 @@ class ModelProperty {
 
   late String _name;
 
-  late int _type, _flags;
+  late int _type, _flags, _generatorFlags;
   IdUid? _indexId;
   ModelEntity? entity;
   String? relationTarget;
@@ -49,6 +49,16 @@ class ModelProperty {
       throw ArgumentError('flags must be defined and may not be < 0');
     }
     _flags = value;
+  }
+
+  int get generatorFlags => _generatorFlags;
+
+  set generatorFlags(int? value) {
+    if (value == null || value < 0) {
+      throw ArgumentError('generator flags must be defined and may not be < 0');
+    }
+
+    _generatorFlags = value;
   }
 
   String get dartFieldType => _dartFieldType!;
@@ -92,6 +102,7 @@ class ModelProperty {
   // used in code generator
   ModelProperty.create(this.id, String? name, int? type,
       {int flags = 0,
+      int generatorFlags = 0,
       String? indexId,
       this.entity,
       String? dartFieldType,
@@ -101,6 +112,7 @@ class ModelProperty {
     this.name = name;
     this.type = type;
     this.flags = flags;
+    this.generatorFlags = generatorFlags;
     this.indexId = indexId == null ? null : IdUid.fromString(indexId);
   }
 
@@ -110,11 +122,13 @@ class ModelProperty {
       required String name,
       required int type,
       required int flags,
+      int? generatorFlags,
       IdUid? indexId,
       this.relationTarget})
       : _name = name,
         _type = type,
         _flags = flags,
+        _generatorFlags = generatorFlags ?? 0,
         _indexId = indexId,
         uidRequest = false;
 
@@ -122,6 +136,7 @@ class ModelProperty {
       : this.create(IdUid.fromString(data['id'] as String?),
             data['name'] as String?, data['type'] as int?,
             flags: data['flags'] as int? ?? 0,
+            generatorFlags: data['generatorFlags'] as int? ?? 0,
             indexId: data['indexId'] as String?,
             entity: entity,
             dartFieldType: data['dartFieldType'] as String?,
@@ -134,6 +149,7 @@ class ModelProperty {
     ret['name'] = name;
     ret['type'] = type;
     if (flags != 0) ret['flags'] = flags;
+    if (generatorFlags != 0) ret['generatorFlags'] = generatorFlags;
     if (indexId != null) ret['indexId'] = indexId!.toString();
     if (relationTarget != null) ret['relationTarget'] = relationTarget;
     if (!forModelJson && _dartFieldType != null) {
@@ -144,6 +160,7 @@ class ModelProperty {
   }
 
   bool hasFlag(int flag) => (flags & flag) == flag;
+  bool hasGeneratorFlag(int flag) => (generatorFlags & flag) == flag;
 
   bool hasIndexFlag() =>
       hasFlag(OBXPropertyFlags.INDEXED) ||
@@ -167,6 +184,7 @@ class ModelProperty {
     result += ' type:${obxPropertyTypeToString(type)}';
     if (!isSigned) result += ' unsigned';
     result += ' flags:$flags';
+    result += ' generatorFlags:$generatorFlags';
 
     if (hasIndexFlag()) {
       result += ' index:' +

--- a/objectbox/test/entity_immutable.dart
+++ b/objectbox/test/entity_immutable.dart
@@ -1,0 +1,25 @@
+import 'package:objectbox/objectbox.dart';
+
+// Testing a model for immutable entities
+@Entity()
+class TestEntityImmutable {
+  @Id(useCopyWith: true)
+  final int? id;
+
+  @Unique(onConflict: ConflictStrategy.replace)
+  final int unique;
+
+  final int payload;
+
+  TestEntityImmutable copyWith({int? id, int? unique, int? payload}) =>
+      TestEntityImmutable(
+        id: id,
+        unique: unique ?? this.unique,
+        payload: payload ?? this.payload,
+      );
+
+  TestEntityImmutable({this.id, required this.unique, required this.payload});
+
+  TestEntityImmutable copyWithId(int newId) =>
+      (id != newId) ? copyWith(id: newId) : this;
+}

--- a/objectbox/test/immutable_test.dart
+++ b/objectbox/test/immutable_test.dart
@@ -1,0 +1,44 @@
+import 'package:collection/collection.dart';
+import 'package:test/test.dart';
+
+import 'entity_immutable.dart';
+import 'objectbox.g.dart';
+import 'test_env.dart';
+
+// We want to have types explicit - verifying the return types of functions.
+// ignore_for_file: omit_local_variable_types
+
+void main() {
+  late TestEnv env;
+  late Box<TestEntityImmutable> box;
+
+  setUp(() {
+    env = TestEnv('entity_immutable');
+    box = env.store.box();
+  });
+  tearDown(() => env.closeAndDelete());
+
+  test('Query with no conditions, and order as desc ints', () {
+    box.putMany(<TestEntityImmutable>[
+      TestEntityImmutable(unique: 1, payload: 1),
+      TestEntityImmutable(unique: 10, payload: 10),
+      TestEntityImmutable(unique: 2, payload: 2),
+      TestEntityImmutable(unique: 100, payload: 100),
+      TestEntityImmutable(unique: 0, payload: 0),
+      TestEntityImmutable(unique: 50, payload: 0),
+    ]);
+
+    final query = (box.query()
+          ..order(TestEntityImmutable_.payload, flags: Order.descending))
+        .build();
+    var listDesc = query.find();
+
+    expect(listDesc.map((t) => t.payload).toList(), [100, 10, 2, 1, 0, 0]);
+
+    box.put(TestEntityImmutable(unique: 50, payload: 50));
+
+    listDesc = query.find();
+    expect(listDesc.map((t) => t.payload).toList(), [100, 50, 10, 2, 1, 0]);
+    query.close();
+  });
+}

--- a/objectbox/test/objectbox-model.json
+++ b/objectbox/test/objectbox-model.json
@@ -527,16 +527,44 @@
         }
       ],
       "relations": []
+    },
+    {
+      "id": "12:3755469960880688715",
+      "lastPropertyId": "3:4328105509779076145",
+      "name": "TestEntityImmutable",
+      "properties": [
+        {
+          "id": "1:2702147992811450538",
+          "name": "id",
+          "type": 6,
+          "flags": 1,
+          "generatorFlags": 65536
+        },
+        {
+          "id": "2:8497246254690861169",
+          "name": "unique",
+          "type": 6,
+          "flags": 32808,
+          "indexId": "22:5208599577901675227"
+        },
+        {
+          "id": "3:4328105509779076145",
+          "name": "payload",
+          "type": 6
+        }
+      ],
+      "relations": []
     }
   ],
-  "lastEntityId": "10:8814538095619551454",
-  "lastIndexId": "20:4846837430056399798",
+  "lastEntityId": "12:3755469960880688715",
+  "lastIndexId": "22:5208599577901675227",
   "lastRelationId": "1:2155747579134420981",
   "lastSequenceId": "0:0",
   "modelVersion": 5,
   "modelVersionParserMinimum": 5,
   "retiredEntityUids": [
-    2679953000475642792
+    2679953000475642792,
+    1095349603547153763
   ],
   "retiredIndexUids": [],
   "retiredPropertyUids": [
@@ -554,7 +582,10 @@
     263290714597678490,
     2191004797635629014,
     6174275661850707374,
-    2900967122054840440
+    2900967122054840440,
+    7226208115703027531,
+    570487578217848006,
+    2435024852950745282
   ],
   "retiredRelationUids": [],
   "version": 1


### PR DESCRIPTION
Immutable entities support (see [Issue-307](https://github.com/objectbox/objectbox-dart/issues/307))
```dart
@Entity()
class TestEntityImmutable {
  @Id(useCopyWith: true)
  final int? id;

  final int payload;

  TestEntityImmutable copyWith({int? id, int? payload}) =>
      TestEntityImmutable(
        id: id,
        payload: payload ?? this.payload,
      );

  TestEntityImmutable({this.id, required this.payload});

  TestEntityImmutable copyWithId(int newId) =>
      (id != newId) ? copyWith(id: newId) : this;
}
```