### PR TITLE
Add async variant of runInTransaction

### DIFF
--- a/.gitlab/merge_request_templates/Default.md
+++ b/.gitlab/merge_request_templates/Default.md
@@ -1,0 +1,24 @@
+## What does this MR do?
+
+<!-- Briefly describe what this MR is about. -->
+
+## Author's checklist
+
+- [ ] The MR fully addresses the requirements of the associated task.
+- [ ] I did a self-review of the changes and did not spot any issues. Among others, this includes:
+  * I added unit tests for new/changed behavior; all test pass.
+  * My code conforms to our coding standards and guidelines.
+  * My changes are prepared in a way that makes the review straightforward for the reviewer.
+- [ ] I amended [`CHANGELOG.md`](objectbox/CHANGELOG.md) if this affects users in any way.
+
+## Review checklist
+
+- [ ] I reviewed all changes line-by-line and addressed relevant issues 
+- [ ] The requirements of the associated task are fully met
+- [ ] I can confirm that:  
+  * CI passes
+  * Coverage percentages do not decrease
+  * New code conforms to standards and guidelines
+  * If applicable, additional checks were done for special code changes (e.g. core performance, binary size, OSS licenses)
+
+/assign me

--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## latest
 
+* The native ObjectBox library is also searched for in the `lib` subfolder on desktop OS (macOS,
+  Linux, Windows). This is where the [`install.sh`](/install.sh) script downloads it by default.
+  E.g. it is no longer necessary to install the library globally to run `dart test` or `flutter test`.
+
 ## 1.4.1 (2022-03-01)
 
 * Resolve "another store is still open" issue after Flutter hot restart (hot reload continues to work). #387

--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## latest
+* Rename `Store.runIsolated` to `runAsync`, drop unused `mode` parameter, propagate errors and
+  handle premature isolate exit.
 
 * The native ObjectBox library is also searched for in the `lib` subfolder on desktop OS (macOS,
   Linux, Windows). This is where the [`install.sh`](/install.sh) script downloads it by default.

--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## latest
+* Add `Store.runInTransactionAsync` to run database operations asynchronously in the background
+  (requires Flutter 2.8.0/Dart 2.15.0 or newer).
 * Rename `Store.runIsolated` to `runAsync`, drop unused `mode` parameter, propagate errors and
   handle premature isolate exit.
 

--- a/objectbox/example/flutter/objectbox_demo/lib/main.dart
+++ b/objectbox/example/flutter/objectbox_demo/lib/main.dart
@@ -44,9 +44,9 @@ class _MyHomePageState extends State<MyHomePage> {
   final _noteInputController = TextEditingController();
   final _listController = StreamController<List<Note>>(sync: true);
 
-  void _addNote() {
+  Future<void> _addNote() async {
     if (_noteInputController.text.isEmpty) return;
-    objectbox.noteBox.put(Note(_noteInputController.text));
+    await objectbox.addNote(_noteInputController.text);
     _noteInputController.text = '';
   }
 

--- a/objectbox/example/flutter/objectbox_demo/lib/objectbox.dart
+++ b/objectbox/example/flutter/objectbox_demo/lib/objectbox.dart
@@ -40,6 +40,25 @@ class ObjectBox {
       Note('Delete notes by tapping on one'),
       Note('Write a demo app for ObjectBox')
     ];
-    noteBox.putMany(demoNotes);
+    store.runInTransactionAsync(TxMode.write, _putNotesInTx, demoNotes);
+  }
+
+  static void _putNotesInTx(Store store, List<Note> notes) =>
+      store.box<Note>().putMany(notes);
+
+  /// Add a note within a transaction.
+  ///
+  /// To avoid frame drops, run ObjectBox operations that take longer than a
+  /// few milliseconds, e.g. putting many objects, in an isolate with its
+  /// own Store instance.
+  /// For this example only a single object is put which would also be fine if
+  /// done here directly.
+  Future<void> addNote(String text) =>
+      store.runInTransactionAsync(TxMode.write, _addNoteInTx, text);
+
+  static void _addNoteInTx(Store store, String text) {
+    // Perform ObjectBox operations that take longer than a few milliseconds
+    // here. To keep it simple, this example just puts a single object.
+    store.box<Note>().put(Note(text));
   }
 }

--- a/objectbox/example/flutter/objectbox_demo/lib/objectbox.dart
+++ b/objectbox/example/flutter/objectbox_demo/lib/objectbox.dart
@@ -56,6 +56,9 @@ class ObjectBox {
   Future<void> addNote(String text) =>
       store.runInTransactionAsync(TxMode.write, _addNoteInTx, text);
 
+  /// Note: due to [dart-lang/sdk#36983](https://github.com/dart-lang/sdk/issues/36983)
+  /// not using a closure as it may capture more objects than expected.
+  /// These might not be send-able to an isolate. See Store.runAsync for details.
   static void _addNoteInTx(Store store, String text) {
     // Perform ObjectBox operations that take longer than a few milliseconds
     // here. To keep it simple, this example just puts a single object.

--- a/objectbox/example/flutter/objectbox_demo_sync/lib/main.dart
+++ b/objectbox/example/flutter/objectbox_demo_sync/lib/main.dart
@@ -44,9 +44,9 @@ class _MyHomePageState extends State<MyHomePage> {
   final _noteInputController = TextEditingController();
   final _listController = StreamController<List<Note>>(sync: true);
 
-  void _addNote() {
+  Future<void> _addNote() async {
     if (_noteInputController.text.isEmpty) return;
-    objectbox.noteBox.put(Note(_noteInputController.text));
+    await objectbox.addNote(_noteInputController.text);
     _noteInputController.text = '';
   }
 

--- a/objectbox/example/flutter/objectbox_demo_sync/lib/objectbox.dart
+++ b/objectbox/example/flutter/objectbox_demo_sync/lib/objectbox.dart
@@ -42,4 +42,20 @@ class ObjectBox {
         );
     return ObjectBox._create(store);
   }
+
+  /// Add a note within a transaction.
+  ///
+  /// To avoid frame drops, run ObjectBox operations that take longer than a
+  /// few milliseconds, e.g. putting many objects, in an isolate with its
+  /// own Store instance.
+  /// For this example only a single object is put which would also be fine if
+  /// done here directly.
+  Future<void> addNote(String text) =>
+      store.runInTransactionAsync(TxMode.write, _addNoteInTx, text);
+
+  static void _addNoteInTx(Store store, String text) {
+    // Perform ObjectBox operations that take longer than a few milliseconds
+    // here. To keep it simple, this example just puts a single object.
+    store.box<Note>().put(Note(text));
+  }
 }

--- a/objectbox/example/flutter/objectbox_demo_sync/lib/objectbox.dart
+++ b/objectbox/example/flutter/objectbox_demo_sync/lib/objectbox.dart
@@ -53,6 +53,9 @@ class ObjectBox {
   Future<void> addNote(String text) =>
       store.runInTransactionAsync(TxMode.write, _addNoteInTx, text);
 
+  /// Note: due to [dart-lang/sdk#36983](https://github.com/dart-lang/sdk/issues/36983)
+  /// not using a closure as it may capture more objects than expected.
+  /// These might not be send-able to an isolate. See Store.runAsync for details.
   static void _addNoteInTx(Store store, String text) {
     // Perform ObjectBox operations that take longer than a few milliseconds
     // here. To keep it simple, this example just puts a single object.

--- a/objectbox/lib/src/native/store.dart
+++ b/objectbox/lib/src/native/store.dart
@@ -432,13 +432,23 @@ class Store {
   /// Spawns an isolate, runs [callback] in that isolate passing it [param] with
   /// its own Store and returns the result of callback.
   ///
+  /// ```dart
+  /// String? readNameAndRemove(Store store, int objectId) {
+  ///   var box = store.box<User>();
+  ///   final nameOrNull = box.get(objectId)?.name;
+  ///   box.remove(objectId);
+  ///   return nameOrNull;
+  /// }
+  /// await store.runAsync(readNameAndRemove, objectId);
+  /// ```
+  ///
   /// Instances of [callback] must be top-level functions or static methods
   /// of classes, not closures or instance methods of objects.
   ///
   /// Note: this requires Dart 2.15.0 or newer
   /// (shipped with Flutter 2.8.0 or newer).
-  Future<R> runIsolated<P, R>(
-      TxMode mode, FutureOr<R> Function(Store, P) callback, P param) async {
+  Future<R> runAsync<P, R>(
+      FutureOr<R> Function(Store, P) callback, P param) async {
     final resultPort = ReceivePort();
     final exitPort = ReceivePort();
     final errorPort = ReceivePort();
@@ -482,6 +492,21 @@ class Store {
     isolate.kill();
     return isolateResult.future;
   }
+
+  /// Deprecated. Use [runAsync] instead. Will be removed in a future release.
+  ///
+  /// Spawns an isolate, runs [callback] in that isolate passing it [param] with
+  /// its own Store and returns the result of callback.
+  ///
+  /// Instances of [callback] must be top-level functions or static methods
+  /// of classes, not closures or instance methods of objects.
+  ///
+  /// Note: this requires Dart 2.15.0 or newer
+  /// (shipped with Flutter 2.8.0 or newer).
+  @Deprecated('Use `runAsync` instead. Will be removed in a future release.')
+  Future<R> runIsolated<P, R>(TxMode mode,
+          FutureOr<R> Function(Store, P) callback, P param) async =>
+      runAsync(callback, param);
 
   /// Internal only - bypasses the main checks for async functions, you may
   /// only pass synchronous callbacks!

--- a/objectbox/lib/src/native/store.dart
+++ b/objectbox/lib/src/native/store.dart
@@ -417,8 +417,13 @@ class Store {
       _IsoPass<P, R> isoPass) async {
     final store = Store.attach(isoPass.model, isoPass.dbDirectoryPath,
         queriesCaseSensitiveDefault: isoPass.queriesCaseSensitiveDefault);
-    final result = await isoPass.runFn(store);
-    store.close();
+    final R result;
+    try {
+      result = await isoPass.runFn(store);
+    } finally {
+      store.close();
+    }
+
     // Note: maybe replace with Isolate.exit (and remove kill call in
     // runIsolated) once min Dart SDK 2.15.
     isoPass.resultPort?.send(result);

--- a/objectbox/lib/src/native/store.dart
+++ b/objectbox/lib/src/native/store.dart
@@ -482,6 +482,11 @@ class Store {
   /// top-level function, static method or a closure that only captures objects
   /// that can be sent to an isolate.
   ///
+  /// Warning: Due to
+  /// [dart-lang/sdk#36983](https://github.com/dart-lang/sdk/issues/36983) a
+  /// closure may capture more objects than expected, even if they are not
+  /// directly used in the closure itself.
+  ///
   /// The types `P` (type of the parameter to be passed to the callback) and
   /// `R` (type of the result returned by the callback) must be able to be sent
   /// to or received from an isolate. The same applies to errors originating

--- a/objectbox/test/box_test.dart
+++ b/objectbox/test/box_test.dart
@@ -553,6 +553,17 @@ void main() {
     expect(count, equals(6));
   });
 
+  test('simple write in txn works - async', () async {
+    int count;
+    void callback(Store store, List<TestEntity> param) {
+      store.box<TestEntity>().putMany(param);
+    }
+
+    await store.runInTransactionAsync(TxMode.write, callback, simpleItems());
+    count = box.count();
+    expect(count, equals(6));
+  }, skip: notAtLeastDart2_15_0());
+
   test('failing transactions', () {
     expect(
         () => store.runInTransaction(TxMode.write, () {
@@ -568,6 +579,22 @@ void main() {
     expect(box.count(), equals(0));
   });
 
+  test('failing transactions - async', () async {
+    expect(
+        () async => await store.runInTransactionAsync(TxMode.write,
+                (Store store, List<TestEntity> param) {
+              store.box<TestEntity>().putMany(param);
+              // note: we're throwing conditionally (but always true) so that
+              // the return type is not [Never]. See [Transaction.execute()]
+              // testing for the return type to be a [Future]. [Never] is a
+              // base class to everything, so a [Future] is also a [Never].
+              if (1 + 1 == 2) throw 'test-exception';
+              return 1;
+            }, simpleItems()),
+        throwsA('test-exception'));
+    expect(box.count(), equals(0));
+  }, skip: notAtLeastDart2_15_0());
+
   test('recursive write in write transaction', () {
     store.runInTransaction(TxMode.write, () {
       box.putMany(simpleItems());
@@ -578,6 +605,22 @@ void main() {
     expect(box.count(), equals(12));
   });
 
+  test('recursive write in write transaction - async', () async {
+    await store.runInTransactionAsync(TxMode.write,
+        (Store store, List<TestEntity> param) {
+      final box = store.box<TestEntity>();
+      box.putMany(param);
+      store.runInTransaction(TxMode.write, () {
+        // Re-set IDs to re-insert.
+        for (var element in param) {
+          element.id = 0;
+        }
+        box.putMany(param);
+      });
+    }, simpleItems());
+    expect(box.count(), equals(12));
+  }, skip: notAtLeastDart2_15_0());
+
   test('recursive read in write transaction', () {
     int count = store.runInTransaction(TxMode.write, () {
       box.putMany(simpleItems());
@@ -585,6 +628,16 @@ void main() {
     });
     expect(count, equals(6));
   });
+
+  test('recursive read in write transaction - async', () async {
+    int count = await store.runInTransactionAsync(TxMode.write,
+        (Store store, List<TestEntity> param) {
+      final box = store.box<TestEntity>();
+      box.putMany(param);
+      return store.runInTransaction(TxMode.read, box.count);
+    }, simpleItems());
+    expect(count, equals(6));
+  }, skip: notAtLeastDart2_15_0());
 
   test('recursive write in read -> fails during creation', () {
     expect(
@@ -596,6 +649,19 @@ void main() {
         throwsA(predicate((StateError e) =>
             e.toString().contains('failed to create transaction'))));
   });
+
+  test('recursive write in async read -> fails during creation', () {
+    expect(
+        () => store.runInTransactionAsync(TxMode.read,
+                (Store store, List<TestEntity> param) {
+              final box = store.box<TestEntity>();
+              box.count();
+              return store.runInTransaction(
+                  TxMode.write, () => box.putMany(param));
+            }, simpleItems()),
+        throwsA(predicate((StateError e) => e.toString().contains(
+            'Bad state: failed to create transaction: 10001 Cannot start a write transaction inside a read only transaction'))));
+  }, skip: notAtLeastDart2_15_0());
 
   test('failing in recursive txn', () {
     store.runInTransaction(TxMode.write, () {

--- a/objectbox/test/store_test.dart
+++ b/objectbox/test/store_test.dart
@@ -194,7 +194,7 @@ void main() {
   test('store run in isolate', () async {
     final env = TestEnv('store');
     final id = env.box.put(TestEntity(tString: 'foo'));
-    final futureResult = env.store.runAsync(readStringAndRemove, id);
+    final futureResult = env.store.runAsync(_readStringAndRemove, id);
     print('Count in main isolate: ${env.box.count()}');
     final String x = await futureResult;
     expect(x, 'foo!');
@@ -203,7 +203,7 @@ void main() {
   }, skip: notAtLeastDart2_15_0());
 }
 
-Future<String> readStringAndRemove(Store store, int id) async {
+Future<String> _readStringAndRemove(Store store, int id) async {
   var box = store.box<TestEntity>();
   var testEntity = box.get(id);
   final result = testEntity!.tString! + '!';

--- a/objectbox/test/store_test.dart
+++ b/objectbox/test/store_test.dart
@@ -191,11 +191,10 @@ void main() {
     Directory('store').deleteSync(recursive: true);
   });
 
-  test('store_runInIsolatedTx', () async {
+  test('store run in isolate', () async {
     final env = TestEnv('store');
     final id = env.box.put(TestEntity(tString: 'foo'));
-    final futureResult =
-        env.store.runIsolated(TxMode.write, readStringAndRemove, id);
+    final futureResult = env.store.runAsync(readStringAndRemove, id);
     print('Count in main isolate: ${env.box.count()}');
     final String x;
     try {
@@ -205,7 +204,7 @@ void main() {
           .firstMatch(Platform.version)
           ?.group(0);
       if (dartVersion != null && dartVersion.compareTo('2.15.0') < 0) {
-        print('runIsolated requires Dart 2.15, ignoring error.');
+        print('API requires Dart 2.15, ignoring error.');
         env.closeAndDelete();
         return;
       } else {

--- a/objectbox/test/store_test.dart
+++ b/objectbox/test/store_test.dart
@@ -196,25 +196,11 @@ void main() {
     final id = env.box.put(TestEntity(tString: 'foo'));
     final futureResult = env.store.runAsync(readStringAndRemove, id);
     print('Count in main isolate: ${env.box.count()}');
-    final String x;
-    try {
-      x = await futureResult;
-    } catch (e) {
-      final dartVersion = RegExp('([0-9]+).([0-9]+).([0-9]+)')
-          .firstMatch(Platform.version)
-          ?.group(0);
-      if (dartVersion != null && dartVersion.compareTo('2.15.0') < 0) {
-        print('API requires Dart 2.15, ignoring error.');
-        env.closeAndDelete();
-        return;
-      } else {
-        rethrow;
-      }
-    }
+    final String x = await futureResult;
     expect(x, 'foo!');
     expect(env.box.count(), 0); // Must be removed once awaited
     env.closeAndDelete();
-  });
+  }, skip: notAtLeastDart2_15_0());
 }
 
 Future<String> readStringAndRemove(Store store, int id) async {

--- a/objectbox/test/test_env.dart
+++ b/objectbox/test/test_env.dart
@@ -64,3 +64,14 @@ Matcher sameAsList<T>(List<T> list) => unorderedEquals(list);
 // We need to do this to receive an event in the stream before processing
 // the remainder of the test case.
 final yieldExecution = () async => await Future<void>.delayed(Duration.zero);
+
+dynamic notAtLeastDart2_15_0() {
+  final dartVersion = RegExp('([0-9]+).([0-9]+).([0-9]+)')
+      .firstMatch(Platform.version)
+      ?.group(0);
+  if (dartVersion != null && dartVersion.compareTo('2.15.0') < 0) {
+    return 'Test requires Dart 2.15.0, skipping.';
+  } else {
+    return false;
+  }
+}


### PR DESCRIPTION
Adds `Store.runInTransactionAsync` which wraps `Store.runInTransaction` within `Store.runAsync`.

This also has bug fixes and improvements and a name change for `runIsolated`, now known as `runAsync`.