### PR TITLE
CI: test latest Dart SDK

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -54,7 +54,6 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ matrix.sdk }}
-      - run: dart --version
       - uses: actions/checkout@v2
       - name: Install ObjectBox C-API
         working-directory: objectbox

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -42,9 +42,9 @@ jobs:
           - ubuntu-20.04
         sdk:
           - stable
+          - 2.16.2
           - 2.15.1
           - 2.14.4
-          - 2.13.4
           - 2.12.0  # currently the lowest fully supported version (i.e. generator + lib)
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ jobs:
   generator:
     runs-on: ubuntu-20.04
     container:
-      image: google/dart:latest
+      image: google/dart:2.17.0
     steps:
       - uses: actions/checkout@v2
       - name: Install ObjectBox C-API
@@ -30,6 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.0.0
+          cache: true
       - run: ./tool/init.sh
 
   lib:
@@ -41,7 +44,7 @@ jobs:
           - macos-11
           - ubuntu-20.04
         sdk:
-          - stable
+          - 2.17.0
           - 2.16.2
           - 2.15.1
           - 2.14.4
@@ -67,6 +70,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 2.17.0
       - uses: actions/checkout@v2
       - name: Install ObjectBox C-API
         run: ./install.sh
@@ -90,15 +95,16 @@ jobs:
           - windows-2022
           - macos-11
           - ubuntu-20.04
-        channel:
-          - beta
-          - stable
+        flutter-version:
+          - 3.0.0
+          - 2.0.0 # Lowest supported version, based on lowest supported Dart SDK, see pubspec.yaml files
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v2
         with:
-          channel: ${{ matrix.channel }}
+          flutter-version: ${{ matrix.flutter-version }}
+          cache: true
       - uses: actions/setup-java@v2 # macos-10.15 and windows-2019 default to Java 8, but Android Plugin requires 11
         with:
           distribution: 'temurin'

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ jobs:
   generator:
     runs-on: ubuntu-20.04
     container:
-      image: google/dart:2.17.0
+      image: dart:2.17.0
     steps:
       - uses: actions/checkout@v2
       - name: Install ObjectBox C-API

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -96,7 +96,9 @@ jobs:
           - ubuntu-20.04
         flutter-version:
           - 3.0.0
-          - 2.0.0 # Lowest supported version, based on lowest supported Dart SDK, see pubspec.yaml files
+          - 2.2.0
+          # 2.0.0 technically lowest supported, but need 2.2.0 to correctly resolve null safety dependencies.
+          # https://github.com/flutter/flutter/issues/77282
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -91,7 +91,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2022
           - macos-11
           - ubuntu-20.04
         flutter-version:
@@ -99,6 +98,11 @@ jobs:
           - 2.2.0
           # 2.0.0 technically lowest supported, but need 2.2.0 to correctly resolve null safety dependencies.
           # https://github.com/flutter/flutter/issues/77282
+        include:
+          - flutter-version: 3.0.0 # Flutter 2.9 and newer need Visual Studio 2022 to build desktop.
+            os: windows-2022
+          - flutter-version: 2.2.0 # Flutter 2.8.1 and older need Visual Studio 2019 to build desktop.
+            os: windows-2019
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -106,12 +110,14 @@ jobs:
         with:
           flutter-version: ${{ matrix.flutter-version }}
           cache: true
-      - uses: actions/setup-java@v2 # macos-10.15 and windows-2019 default to Java 8, but Android Plugin requires 11
+      # macos-11 and windows-2019/2022 default to Java 8, but Android Plugin requires 11.
+      - uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: '11'
       - run: echo $PATH
       - run: flutter --version
+      # https://docs.flutter.dev/desktop#additional-linux-requirements
       - if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: ./tool/apt-install.sh ninja-build pkg-config libgtk-3-dev
       - run: make integration-test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
   analyze:
     runs-on: ubuntu-20.04
     container:
-      image: google/dart:2.17.0
+      image: dart:2.17.0
     steps:
       - uses: actions/checkout@v2
       - run: dart run build_runner build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           flutter-version: 3.0.0
           cache: true
-      - name: Generage test coverage
+      - name: Generate test coverage
         working-directory: objectbox
         run: |
           ../tool/apt-install.sh lcov

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
   analyze:
     runs-on: ubuntu-20.04
     container:
-      image: google/dart:latest
+      image: google/dart:2.17.0
     steps:
       - uses: actions/checkout@v2
       - run: dart run build_runner build
@@ -22,7 +22,7 @@ jobs:
       - run: dart format --set-exit-if-changed --fix .
 
   pana:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: axel-op/dart-package-analyzer@v3
@@ -41,10 +41,13 @@ jobs:
           fi
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.0.0
+          cache: true
       - name: Generage test coverage
         working-directory: objectbox
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
 variables:
   # Note: use specific tags as docker images may not always be pulled due to "if-not-present" pull policy.
   #       Thus, do not use tags like latest/beta, but check https://hub.docker.com/_/dart?tab=tags for latest.
-  DART_VERSION: '2.16.2'
+  DART_VERSION: '2.17.0'
 
 # Make PUB_CACHE cacheable in GitLab;
 # see also https://gitlab.com/gitlab-org/gitlab/-/merge_requests/77791/diffs and
@@ -67,4 +67,5 @@ test-lib:linux:x64:
     matrix:
       # Note: use specific tags as docker images may not always be pulled due to "if-not-present" pull policy.
       #       Thus, do not use tags like latest/beta, but check https://hub.docker.com/_/dart?tab=tags for latest.
-      - DART_VERSION: [ '2.13.4', '2.14.4', '2.15.1', '2.16.1', '2.16.2' ]
+      # Always include lowest supported version (see sdk key in objectbox and generator pubspec.yaml).
+      - DART_VERSION: [ '2.12', '2.14.4', '2.15.1', '2.16.1', '2.16.2', '2.17.0' ]

--- a/objectbox/Makefile
+++ b/objectbox/Makefile
@@ -11,22 +11,22 @@ help:			## Show this help
 all: depend test valgrind-test integration-test
 
 depend:			## Build dependencies
-	pub get
+	dart pub get
 	../install.sh
 
 test: 			## Test all targets
-	pub run build_runner build
-	pub run test
+	dart run build_runner build
+	dart run test
 
 coverage: 			## Calculate test coverage
-	pub run build_runner build
+	dart run build_runner build
     # Note: only flutter test generates `.lcov` - can't use `dart test`
 	flutter test --coverage
 	lcov --remove coverage/lcov.info 'lib/src/native/sync.dart' 'lib/src/native/bindings/objectbox_c.dart' 'lib/src/native/bindings/bindings.dart' 'lib/src/modelinfo/*' -o coverage/lcov.info
 	genhtml coverage/lcov.info -o coverage/html || true
 
 valgrind-test: 		## Test all targets with valgrind
-	pub run build_runner build
+	dart run build_runner build
 	./tool/valgrind.sh
 
 integration-test:	## Execute integration tests
@@ -35,4 +35,4 @@ integration-test:	## Execute integration tests
 	./tool/integration-test.sh example/flutter/objectbox_demo_sync
 
 format:			## Format all code
-	dartfmt -w .
+	dart format .

--- a/objectbox/example/flutter/objectbox_demo/pubspec.yaml
+++ b/objectbox/example/flutter/objectbox_demo/pubspec.yaml
@@ -3,8 +3,7 @@ description: An example project for the objectbox-dart binding.
 version: 0.3.0+1
 
 environment:
-  sdk: ^2.12.0
-  flutter: ^2.0.0
+  sdk: ">=2.13.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -32,8 +31,3 @@ dependency_overrides:
     path: ../../../../generator
   objectbox_flutter_libs:
     path: ../../../../flutter_libs
-
-  # Temporary flutter_driver issue, same as https://github.com/flutter/flutter/issues/77282
-  archive: ^3.0.0
-  convert: ^3.0.0
-  crypto: ^3.0.0

--- a/objectbox/example/flutter/objectbox_demo_relations/pubspec.yaml
+++ b/objectbox/example/flutter/objectbox_demo_relations/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.13.0 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/objectbox/example/flutter/objectbox_demo_relations/pubspec.yaml
+++ b/objectbox/example/flutter/objectbox_demo_relations/pubspec.yaml
@@ -50,7 +50,6 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^1.0.0
-  test: ^1.17.10
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/objectbox/example/flutter/objectbox_demo_sync/pubspec.yaml
+++ b/objectbox/example/flutter/objectbox_demo_sync/pubspec.yaml
@@ -3,8 +3,7 @@ description: An example project for the objectbox-dart binding.
 version: 0.3.0+1
 
 environment:
-  sdk: ^2.12.0
-  flutter: ^2.0.0
+  sdk: ">=2.13.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -32,8 +31,3 @@ dependency_overrides:
     path: ../../../../generator
   objectbox_sync_flutter_libs:
     path: ../../../../sync_flutter_libs
-
-  # Temporary flutter_driver issue, same as https://github.com/flutter/flutter/issues/77282
-  archive: ^3.0.0
-  convert: ^3.0.0
-  crypto: ^3.0.0

--- a/objectbox/tool/integration-test.sh
+++ b/objectbox/tool/integration-test.sh
@@ -15,7 +15,9 @@ cd "${root}/$1"
 flutter clean
 flutter pub get
 
-flutter pub run build_runner build --delete-conflicting-outputs
+# Flutter ~2.0 fails: The pubspec.lock file has changed since the .dart_tool/package_config.json file was generated, please run "pub get" again.
+generateCmd="flutter pub run build_runner build --delete-conflicting-outputs"
+$generateCmd || (flutter pub get && $generateCmd)
 
 # flutter drive is currently not available in GitHub Actions (TODO start an emulator/simulator?)
 if [[ "${GITHUB_ACTIONS:-}" == "" ]]; then


### PR DESCRIPTION
- Test Dart SDK 2.17.0 and Flutter 3.0.0.
- Use fixed versions of Dart and Flutter, also runners. E.g. `google/dart` was deprecated and was not longer using the latest SDK. Also avoids builds on `main` branch suddenly failing even if e.g. just editing a README.