### PR TITLE
CI: restore testability of Flutter 2.5.0

### DIFF
--- a/objectbox/example/flutter/objectbox_demo_relations/pubspec.yaml
+++ b/objectbox/example/flutter/objectbox_demo_relations/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   objectbox: ^1.6.2
   objectbox_flutter_libs: any
   intl: any
-  path_provider: ^2.0.11
-  path: ^1.8.0
+  path_provider: ^2.0.10 # 2.0.11+ requires Flutter 2.8.0
+  path: ^1.8.0 # flutter_test depends on path 1.8.0
 
 dev_dependencies:
   flutter_test:

--- a/objectbox/example/flutter/objectbox_demo_relations/pubspec.yaml
+++ b/objectbox/example/flutter/objectbox_demo_relations/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   objectbox_flutter_libs: any
   intl: any
   path_provider: ^2.0.11
-  path: ^1.8.1
+  path: ^1.8.0
 
 dev_dependencies:
   flutter_test:

--- a/objectbox/tool/integration-test.sh
+++ b/objectbox/tool/integration-test.sh
@@ -25,8 +25,11 @@ if [[ "${GITHUB_ACTIONS:-}" == "" ]]; then
 fi
 
 # Only test App Bundle build, its the preferred format (and required for new apps on Google Play).
+# On GitHub Actions, only build Android on Linux to reduce build time.
 # flutter build apk
-flutter build appbundle
+if [[ "${GITHUB_ACTIONS:-}" == "" || "$(uname)" == "Linux" ]]; then
+  flutter build appbundle
+fi
 
 if [[ "$(uname)" == "Darwin" ]]; then
   flutter build ios --no-codesign


### PR DESCRIPTION
Also only build Android App Bundle on one desktop system (Ubuntu).