### PR TITLE
Support long (8 byte integer) type

### DIFF
--- a/objectbox/lib/src/annotations.dart
+++ b/objectbox/lib/src/annotations.dart
@@ -86,6 +86,9 @@ enum PropertyType {
   /// size: 4-bytes/32-bits
   int,
 
+  /// size: 8-bytes/64-bits
+  long,
+
   // dart type=int, size: 8-bytes/64-bits
   // no need to specify explicitly, just use [int]
   // long,

--- a/objectbox/lib/src/modelinfo/enums.dart
+++ b/objectbox/lib/src/modelinfo/enums.dart
@@ -51,6 +51,8 @@ int propertyTypeToOBXPropertyType(PropertyType type) {
       return OBXPropertyType.Char;
     case PropertyType.int:
       return OBXPropertyType.Int;
+    case PropertyType.long:
+      return OBXPropertyType.Long;
     case PropertyType.float:
       return OBXPropertyType.Float;
     case PropertyType.date:


### PR DESCRIPTION
closes #529

There already is `OBXPropertyType.Long`, so this PR adds this to the `PropertyType`.