### PR TITLE
Android plugin 8 compatibility

### DIFF
--- a/flutter_libs/android/build.gradle
+++ b/flutter_libs/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.objectbox.objectbox_flutter_libs'
+    }
+
     compileSdkVersion 31
 
     compileOptions {

--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## latest
 
 * Fix crash in Flutter plugin when running in debug mode on iOS. [#561](https://github.com/objectbox/objectbox-dart/issues/561)
+* Support Flutter projects using Android Gradle Plugin 8. [#581](https://github.com/objectbox/objectbox-dart/issues/581)
 
 ## 2.3.1 (2023-10-02)
 

--- a/sync_flutter_libs/android/build.gradle
+++ b/sync_flutter_libs/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.objectbox.objectbox_sync_flutter_libs'
+    }
+
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
Also update plugin files and example files to match templates of Flutter 3.3.10 (or newer when necessary).