### PR TITLE
Add Kotlin DSL (build.gradle.kts) examples and update NDK docs

### DIFF
--- a/dev-doc/updating-c-library.md
+++ b/dev-doc/updating-c-library.md
@@ -42,8 +42,9 @@ For the Flutter plugins on Android ([view releases](https://github.com/objectbox
 
 ```text
 * Update ObjectBox database for Flutter Android apps to 5.1.0-2026-01-19.
-  If your project is [using Admin](https://docs.objectbox.io/data-browser#admin-for-android), make 
-  sure to update to `io.objectbox:objectbox-android-objectbrowser:5.1.0` in `android/app/build.gradle`.
+  If your project is [using Admin](https://docs.objectbox.io/data-browser#admin-for-android), make
+  sure to update to `io.objectbox:objectbox-android-objectbrowser:5.1.0` in `android/app/build.gradle`
+  (or `build.gradle.kts`).
 ```
 
 ```text

--- a/objectbox/CHANGELOG.md
+++ b/objectbox/CHANGELOG.md
@@ -1,12 +1,22 @@
 ## latest
 
+* Add Kotlin DSL (`build.gradle.kts`) example for enabling ObjectBox Admin in Flutter Android
+  projects. Recent Flutter versions create Android projects using Kotlin DSL by default.
+  See the [relations example README](example/flutter/objectbox_demo_relations/README.md) for both
+  Groovy and Kotlin DSL snippets.
+  [#778](https://github.com/objectbox/objectbox-dart/issues/778)
+* Note: the Getting Started documentation no longer recommends setting `ndkVersion` manually as
+  recent Flutter versions (3.27+) include a compatible NDK by default.
+  [#702](https://github.com/objectbox/objectbox-dart/issues/702)
+
 ## 5.2.0 (2026-01-28)
 
 * Allow analyzer versions 9 and 10. [#780](https://github.com/objectbox/objectbox-dart/issues/780)
 * Update ObjectBox database for Flutter Linux/Windows, Dart Native apps to [5.1.0-2026-01-19](https://github.com/objectbox/objectbox-c/releases/tag/v5.1.0).
 * Update ObjectBox database for Flutter Android apps to 5.1.0-2026-01-19.
   If your project is [using Admin](https://docs.objectbox.io/data-browser#admin-for-android), make
-  sure to update to `io.objectbox:objectbox-android-objectbrowser:5.1.0` in `android/app/build.gradle`.
+  sure to update to `io.objectbox:objectbox-android-objectbrowser:5.1.0` in `android/app/build.gradle`
+  (or `build.gradle.kts`).
 * Update ObjectBox database for Flutter iOS/macOS apps to 5.1.1-dev-2026-01-21.
   For existing projects, run `pod repo update` and `pod update ObjectBox` in the `ios` or `macos` directories.
 

--- a/objectbox/README.md
+++ b/objectbox/README.md
@@ -159,6 +159,12 @@ dev_dependencies:
 4. Your project can now use ObjectBox, [continue by defining entity classes](https://docs.objectbox.io/getting-started#define-entity-classes).
 
 > [!NOTE]
+> **Android NDK:** Flutter 3.27 and later include a compatible NDK version by default,
+> so there is no need to manually set `ndkVersion` in `android/app/build.gradle`.
+> For older Flutter versions, check the [troubleshooting page](https://docs.objectbox.io/troubleshooting)
+> if you encounter NDK-related build errors.
+
+> [!NOTE]
 > **For all iOS apps** target iOS 15.0: in `ios/Podfile` change the platform and in the 
 > `ios/Runner.xcodeproj/poject.pbxproj` file update `IPHONEOS_DEPLOYMENT_TARGET` (or open the Runner
 > workspace in Xcode and edit the build setting). In `ios/Flutter/AppframeworkInfo.plist` update 

--- a/objectbox/example/flutter/objectbox_demo_relations/README.md
+++ b/objectbox/example/flutter/objectbox_demo_relations/README.md
@@ -12,6 +12,42 @@ See how to:
 - query for Objects ([objectbox.dart](lib/objectbox.dart) and [tasklist_elements.dart](lib/tasklist_elements.dart))
 - add ObjectBox Admin for debug builds ([objectbox.dart](lib/objectbox.dart), [build.gradle](android/app/build.gradle))
 
+## ObjectBox Admin for Android
+
+To use [ObjectBox Admin](https://docs.objectbox.io/data-browser) for debug builds, add the following
+to `android/app/build.gradle` (Groovy DSL) or `android/app/build.gradle.kts` (Kotlin DSL):
+
+**Groovy DSL** (`build.gradle`):
+
+```groovy
+configurations {
+    debugImplementation {
+        exclude group: 'io.objectbox', module: 'objectbox-android'
+    }
+}
+
+dependencies {
+    debugImplementation("io.objectbox:objectbox-android-objectbrowser:5.1.0")
+}
+```
+
+**Kotlin DSL** (`build.gradle.kts`):
+
+```kotlin
+configurations {
+    named("debugImplementation") {
+        exclude(group = "io.objectbox", module = "objectbox-android")
+    }
+}
+
+dependencies {
+    debugImplementation("io.objectbox:objectbox-android-objectbrowser:5.1.0")
+}
+```
+
+Note: when the objectbox package updates, check if the Android library version above needs to be
+updated as well.
+
 ## Docs
 - [Getting started with ObjectBox](https://docs.objectbox.io/getting-started)
 - [How to use ObjectBox Relations](https://docs.objectbox.io/relations)

--- a/objectbox/example/flutter/objectbox_demo_relations/android/app/build.gradle
+++ b/objectbox/example/flutter/objectbox_demo_relations/android/app/build.gradle
@@ -66,6 +66,20 @@ flutter {
 // Optional: add ObjectBox Admin - https://docs.objectbox.io/data-browser
 // Tell Gradle to exclude the Android library (without Admin)
 // that is added by the objectbox_flutter_libs package for debug builds.
+//
+// Note: this example uses Groovy DSL (build.gradle). If your project uses
+// Kotlin DSL (build.gradle.kts), use this syntax instead:
+//
+//   configurations {
+//       named("debugImplementation") {
+//           exclude(group = "io.objectbox", module = "objectbox-android")
+//       }
+//   }
+//
+//   dependencies {
+//       debugImplementation("io.objectbox:objectbox-android-objectbrowser:5.1.0")
+//   }
+//
 configurations {
     debugImplementation {
         exclude group: 'io.objectbox', module: 'objectbox-android'


### PR DESCRIPTION
## Summary

- **#778**: Add Kotlin DSL (`build.gradle.kts`) snippets for enabling ObjectBox Admin in Flutter Android projects. Recent Flutter versions create Android projects using Kotlin DSL by default, so copying the documented Groovy snippet into a `.kts` file leads to Gradle compilation errors. Both Groovy and Kotlin DSL examples are now provided.
- **#702**: Add a note in the Flutter getting started section that Flutter 3.27+ includes a compatible NDK by default, so manually setting `ndkVersion` is no longer necessary.

## Changes

- `objectbox/example/flutter/objectbox_demo_relations/README.md` — New "ObjectBox Admin for Android" section with side-by-side Groovy and Kotlin DSL examples
- `objectbox/example/flutter/objectbox_demo_relations/android/app/build.gradle` — Inline comment showing the Kotlin DSL equivalent
- `objectbox/CHANGELOG.md` — Added entries in `## latest` for both issues; updated 5.2.0 entry to mention `build.gradle.kts`
- `dev-doc/updating-c-library.md` — Updated CHANGELOG template to mention `build.gradle.kts`
- `objectbox/README.md` — Added note that NDK is handled automatically by Flutter 3.27+

Closes #778
Closes #702