### PR TITLE
fix: resolve FetchContent_Populate deprecation (CMP0169) in Windows CMake

### DIFF
--- a/flutter_libs/windows/CMakeLists.txt
+++ b/flutter_libs/windows/CMakeLists.txt
@@ -70,11 +70,8 @@ FetchContent_Declare(
 )
 
 # FIXED: Use MakeAvailable instead of GetProperties/Populate
-# This handles the download and set-up internally and is the modern standard.
 FetchContent_MakeAvailable(objectbox-download)
 
-# We still need the source directory path to point to the library files
-# After MakeAvailable, the directory variable is named <lowercaseName>_SOURCE_DIR
 set(objectbox_flutter_libs_bundled_libraries
     "${objectbox-download_SOURCE_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}objectbox${CMAKE_SHARED_LIBRARY_SUFFIX}"
     PARENT_SCOPE

--- a/flutter_libs/windows/CMakeLists.txt
+++ b/flutter_libs/windows/CMakeLists.txt
@@ -69,11 +69,12 @@ FetchContent_Declare(
     URL https://github.com/objectbox/objectbox-c/releases/download/v${OBJECTBOX_VERSION}/objectbox-windows-${OBJECTBOX_ARCH}.zip
 )
 
-FetchContent_GetProperties(objectbox-download)
-if(NOT objectbox-download_POPULATED)
-  FetchContent_Populate(objectbox-download)
-endif()
+# FIXED: Use MakeAvailable instead of GetProperties/Populate
+# This handles the download and set-up internally and is the modern standard.
+FetchContent_MakeAvailable(objectbox-download)
 
+# We still need the source directory path to point to the library files
+# After MakeAvailable, the directory variable is named <lowercaseName>_SOURCE_DIR
 set(objectbox_flutter_libs_bundled_libraries
     "${objectbox-download_SOURCE_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}objectbox${CMAKE_SHARED_LIBRARY_SUFFIX}"
     PARENT_SCOPE
@@ -81,8 +82,8 @@ set(objectbox_flutter_libs_bundled_libraries
 
 add_library(objectbox SHARED IMPORTED GLOBAL)
 set_target_properties(objectbox PROPERTIES
-    IMPORTED_LOCATION ${objectbox-download_SOURCE_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}objectbox${CMAKE_SHARED_LIBRARY_SUFFIX}
-    IMPORTED_IMPLIB ${objectbox-download_SOURCE_DIR}/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}objectbox${CMAKE_IMPORT_LIBRARY_SUFFIX}
+    IMPORTED_LOCATION "${objectbox-download_SOURCE_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}objectbox${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    IMPORTED_IMPLIB "${objectbox-download_SOURCE_DIR}/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}objectbox${CMAKE_IMPORT_LIBRARY_SUFFIX}"
 )
 
 target_link_libraries(${PLUGIN_NAME} PRIVATE objectbox)


### PR DESCRIPTION
This PR replaces the deprecated FetchContent_Populate pattern with the modern FetchContent_MakeAvailable in the Windows CMakeLists.txt.

Starting with CMake 3.30, calling FetchContent_Populate directly triggers a deprecation warning (Policy CMP0169). Using FetchContent_MakeAvailable is the recommended approach for CMake 3.14+ and resolves the warning while maintaining backward compatibility.

Changes:

    Updated flutter_libs/windows/CMakeLists.txt to use FetchContent_MakeAvailable.

    Verified build on Windows with CMake 3.30+.