### PR TITLE
Migrate objectbox_flutter_libs to built-in Kotlin

### DIFF
--- a/flutter_libs/CHANGELOG.md
+++ b/flutter_libs/CHANGELOG.md
@@ -1,1 +1,9 @@
+## 5.4.0
+
+* Migrate Android build to use built-in Kotlin (per the official Flutter
+  migration guide: https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors).
+  Removes the legacy `apply plugin: "kotlin-android"` line and the
+  `kotlin-gradle-plugin` classpath from `android/build.gradle`.
+* Bump minimum Dart SDK to `^3.12.0` and Flutter to `>=3.44.0`.
+
 See [ObjectBox changelog](https://pub.dev/packages/objectbox/changelog).

--- a/flutter_libs/android/build.gradle
+++ b/flutter_libs/android/build.gradle
@@ -2,7 +2,6 @@ group = "io.objectbox.objectbox_flutter_libs"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "1.8.22"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.7.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
 
@@ -22,7 +20,6 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
 
 android {
     namespace = "io.objectbox.objectbox_flutter_libs"
@@ -30,12 +27,8 @@ android {
     compileSdk = 35
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     sourceSets {
@@ -51,5 +44,11 @@ android {
         // the C API binding of the ObjectBox Dart package.
         // https://central.sonatype.com/search?q=g:io.objectbox%20objectbox-android
         implementation "io.objectbox:objectbox-android:5.4.2"
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }

--- a/flutter_libs/pubspec.yaml
+++ b/flutter_libs/pubspec.yaml
@@ -3,11 +3,11 @@ description: Superfast NoSQL Flutter / Dart database. This package contains Flut
 # Link to actual directory in repository so file links on pub.dev work.
 repository: https://github.com/objectbox/objectbox-dart/tree/main/flutter_libs
 homepage: https://objectbox.io
-version: 5.3.2
+version: 5.4.0
 
 environment:
-  sdk: ^3.7.0
-  flutter: '>=3.3.0'
+  sdk: ^3.12.0
+  flutter: '>=3.44.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Migrates the `objectbox_flutter_libs` subpackage (the only one in this
monorepo that ships an Android plugin) to use built-in Kotlin per the
official Flutter migration guide:
https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors

This PR touches only the `flutter_libs/` subpackage. Other packages in
this monorepo (e.g. `objectbox`, `objectbox_test`, `sync_flutter_libs`,
`generator`, `benchmark`) are pure Dart and do not ship an Android
plugin, so the migration does not apply to them.

Changes in `flutter_libs/`:
- `android/build.gradle`: removes the `kotlin-gradle-plugin` classpath,
  the `ext.kotlin_version` property, the `apply plugin: "kotlin-android"`
  line, and the legacy `kotlinOptions { jvmTarget = ... }` block from
  inside `android {}`. Adds a top-level
  `kotlin { compilerOptions { jvmTarget = ...JVM_17 } }` block. Bumps
  Java `sourceCompatibility`/`targetCompatibility` from 11 to 17 to
  match the Kotlin jvmTarget.
- `pubspec.yaml`: bumps version `5.3.2` -> `5.4.0`, minimum Dart SDK
  to `^3.12.0`, minimum Flutter to `>=3.44.0` (as required by the new
  `kotlin.compilerOptions` DSL).
- `CHANGELOG.md`: adds a `5.4.0` entry documenting the migration.

Fixes the warning: "Your app uses the following plugins that apply
Kotlin Gradle Plugin (KGP)".

### Validation

Built and validated against a throwaway Flutter 3.44.1 app that depends
on this subpackage via a path dependency:
\`flutter build apk --debug\` -> `app-debug.apk` produced in 38s with
zero KGP deprecation warnings and zero "Inconsistent JVM Target
Compatibility" errors. No standalone example app ships in
`flutter_libs/example/` (the upstream published package also has an
empty example dir pointing to the umbrella `objectbox` package), so the
build was validated via a path-dep throwaway app rather than the
subpackage's own example.

AGP 9.0 will remove support for plugins that apply the Kotlin Gradle
Plugin, so this migration is required for forward compatibility.