### PR TITLE
Add NullableCondition extension for Condition

### DIFF
--- a/objectbox/lib/src/native/query/query.dart
+++ b/objectbox/lib/src/native/query/query.dart
@@ -540,6 +540,34 @@ abstract class Condition<EntityT> {
   }
 }
 
+/// Extension on nullable [Condition] to simplify building queries
+/// where conditions are accumulated conditionally.
+extension NullableCondition<T> on Condition<T>? {
+  /// Combines this condition with [other] using AND.
+  /// If this is null, returns [other] directly.
+  ///
+  /// Useful when building queries where conditions are applied selectively:
+  /// ```dart
+  /// Condition<City>? condition;
+  /// condition = condition.and(City_.district.equals(id));
+  /// condition = condition.and(City_.name.contains(name));
+  /// query = box.query(condition).build();
+  /// ```
+  Condition<T> and(Condition<T> other) => this?.and(other) ?? other;
+
+  /// Combines this condition with [other] using OR.
+  /// If this is null, returns [other] directly.
+  ///
+  /// Useful when building queries where conditions are applied selectively:
+  /// ```dart
+  /// Condition<City>? condition;
+  /// condition = condition.or(City_.district.equals(id));
+  /// condition = condition.or(City_.name.contains(name));
+  /// query = box.query(condition).build();
+  /// ```
+  Condition<T> or(Condition<T> other) => this?.or(other) ?? other;
+}
+
 class _NullCondition<EntityT, DartType> extends Condition<EntityT> {
   final QueryProperty<EntityT, DartType> _property;
   final _ConditionOp _op;


### PR DESCRIPTION
Introduce a `NullableCondition<T>` extension on `Condition<T>?` providing `and(Condition<T>)` and `or(Condition<T>)` helpers. 

These methods return the provided condition when the receiver is null, or delegate to the existing and/or logic otherwise, simplifying conditional accumulation of query conditions and removing boilerplate null checks. Doc examples included to demonstrate usage when building queries.

Usefull when building queries with multiple condition options that can all be supplied as null.

Example:
```dart
Condition<City>? condition;

if (id != null ) condition = condition.and(City_.id.equals(id));
if (name != null && name.isNotEmpty) condition = condition.and(City_.name.contains(name));

query = box.query(condition).build();
```

I always write this extension on all my projects because it makes it much easier to work with lots of conditions. Since `Condition` itself is not nullable, I'd always have to kick start it with something like `City_.id.greaterThan(0)` and then add my conditional conditions (haha).

Providing this extension natively should help everyone, I hope.